### PR TITLE
Add harvester network controller chart

### DIFF
--- a/charts/harvester-network-controller/.helmignore
+++ b/charts/harvester-network-controller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/harvester-network-controller/Chart.yaml
+++ b/charts/harvester-network-controller/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: harvester-network-controller
+description: A Helm chart for Harvester Network Controller
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.0-dev
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0
+
+maintainers:
+  - name: harvester

--- a/charts/harvester-network-controller/README.md
+++ b/charts/harvester-network-controller/README.md
@@ -1,0 +1,32 @@
+# Harvester-Network-Controller Helm Chart
+
+[Harvester Network Contrller](https://github.com/harvester/network-controller-harvester) is a network controller that helps to manage the host network configuration of the Harvester cluster.
+
+Introduction
+------------
+
+This chart installs the network-controller daemonset on the [harvester](https://github.com/harvester/harvester) cluster using the [Helm](https://helm.sh) package manager.
+
+Prerequisites
+-------------
+- [multus-cni](https://github.com/intel/multus-cni) v3.6+
+- Vlan filtering support on bridge
+- Switch to support `trunk` mode
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm repo add harvester https://charts.harvesterhci.io
+helm repo update
+helm install -n $namespace my-release harvester/harvester-network-controller
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm uninstall -n $namespace my-release
+```

--- a/charts/harvester-network-controller/crds/network.harvesterhci.io_clusternetworks.yaml
+++ b/charts/harvester-network-controller/crds/network.harvesterhci.io_clusternetworks.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {}
+  creationTimestamp: null
+  name: clusternetworks.network.harvesterhci.io
+spec:
+  group: network.harvesterhci.io
+  names:
+    kind: ClusterNetwork
+    listKind: ClusterNetworkList
+    plural: clusternetworks
+    shortNames:
+      - cn
+      - cns
+    singular: clusternetwork
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.description
+          name: DESCRIPTION
+          type: string
+        - jsonPath: .enable
+          name: ENABLE
+          type: boolean
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            config:
+              additionalProperties:
+                type: string
+              type: object
+            description:
+              type: string
+            enable:
+              type: boolean
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+          required:
+            - enable
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/harvester-network-controller/crds/network.harvesterhci.io_nodenetworks.yaml
+++ b/charts/harvester-network-controller/crds/network.harvesterhci.io_nodenetworks.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {}
+  creationTimestamp: null
+  name: nodenetworks.network.harvesterhci.io
+spec:
+  group: network.harvesterhci.io
+  names:
+    kind: NodeNetwork
+    listKind: NodeNetworkList
+    plural: nodenetworks
+    shortNames:
+      - nn
+      - nns
+    singular: nodenetwork
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.description
+          name: DESCRIPTION
+          type: string
+        - jsonPath: .spec.nodeName
+          name: NODENAME
+          type: string
+        - jsonPath: .spec.type
+          name: TYPE
+          type: string
+        - jsonPath: .spec.nic
+          name: NIC
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                description:
+                  type: string
+                nic:
+                  type: string
+                nodeName:
+                  type: string
+                type:
+                  enum:
+                    - vlan
+                  type: string
+              required:
+                - nodeName
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      lastUpdateTime:
+                        description: The last time this condition was updated.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of the condition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                networkIDs:
+                  items:
+                    type: integer
+                  type: array
+                networkLinkStatus:
+                  additionalProperties:
+                    properties:
+                      conditions:
+                        items:
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from one status to another.
+                              type: string
+                            lastUpdateTime:
+                              description: The last time this condition was updated.
+                              type: string
+                            message:
+                              description: Human-readable message indicating details about last transition
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type of the condition.
+                              type: string
+                          required:
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      index:
+                        type: integer
+                      ipv4Address:
+                        items:
+                          type: string
+                        type: array
+                      mac:
+                        type: string
+                      masterIndex:
+                        type: integer
+                      promiscuous:
+                        type: boolean
+                      routes:
+                        items:
+                          type: string
+                        type: array
+                      state:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: object
+                nics:
+                  items:
+                    properties:
+                      index:
+                        description: Index of the NIC
+                        type: integer
+                      masterIndex:
+                        description: Index of the NIC's master
+                        type: integer
+                      name:
+                        description: Name of the NIC
+                        type: string
+                      state:
+                        description: State of the NIC, up/down/unknown
+                        type: string
+                      type:
+                        description: Interface type of the NIC
+                        type: string
+                      usedByManagementNetwork:
+                        description: Specify whether used by management network or not
+                        type: boolean
+                    required:
+                      - index
+                      - name
+                      - state
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/harvester-network-controller/templates/NOTES.txt
+++ b/charts/harvester-network-controller/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The harvester-network-controller has been installed into "{{ .Release.Namespace }}" namespace.

--- a/charts/harvester-network-controller/templates/_helpers.tpl
+++ b/charts/harvester-network-controller/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "harvester-network-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "harvester-network-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "harvester-network-controller.labels" -}}
+helm.sh/chart: {{ include "harvester-network-controller.chart" . }}
+{{ include "harvester-network-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: network
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "harvester-network-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "harvester-network-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/harvester-network-controller/templates/daemonset.yaml
+++ b/charts/harvester-network-controller/templates/daemonset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harvester-network-controller.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "harvester-network-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "harvester-network-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "harvester-network-controller.name" . }}
+      hostNetwork: true
+      containers:
+      - name: network
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - harvester-network-controller
+        args:
+        - agent
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /dev
+          name: dev
+        - mountPath: /lib/modules
+          name: modules
+        resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - hostPath:
+            path: /dev
+          name: dev
+        - hostPath:
+            path: /lib/modules
+          name: modules

--- a/charts/harvester-network-controller/templates/deployment.yaml
+++ b/charts/harvester-network-controller/templates/deployment.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harvester-network-controller.labels" . | nindent 4 }}
+  name: {{ include "harvester-network-controller.name" . }}-manager
+spec:
+  replicas: {{ .Values.manager.replicas }}
+  selector:
+    matchLabels:
+      {{- include "harvester-network-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "harvester-network-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "harvester-network-controller.name" . }}
+      containers:
+        - name: network-manager
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - harvester-network-controller
+          args:
+            - manager
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        {{- with .Values.manager.nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.manager.podAntiAffinity }}
+        podAntiAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/harvester-network-controller/templates/rbac.yaml
+++ b/charts/harvester-network-controller/templates/rbac.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "harvester-network-controller.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+rules:
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: [ "*" ]
+  - apiGroups: [ "network.harvesterhci.io" ]
+    resources: [ "clusternetworks", "nodenetworks" ]
+    verbs: [ "*" ]
+  - apiGroups: [ "k8s.cni.cncf.io" ]
+    resources: [ "network-attachment-definitions" ]
+    verbs: [ "get", "watch", "list", "update" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "watch", "list", "update" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps", "events" ]
+    verbs: [ "get", "watch", "list", "update", "create" ]
+  - apiGroups: [ "" ]
+    resources: [ "namespaces" ]
+    verbs: [ "get", "watch", "list" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+  labels:
+  {{- include "harvester-network-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "harvester-network-controller.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "harvester-network-controller.name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/harvester-network-controller/values.yaml
+++ b/charts/harvester-network-controller/values.yaml
@@ -1,0 +1,60 @@
+# Default values for harvester-network-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: rancher/harvester-network-controller
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "master-head"
+
+nameOverride: ""
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+nodeSelector: {}
+
+tolerations:
+  # this toleration is to have the daemonset runnable on master nodes
+  # remove it if your masters can't run pods
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+
+affinity: {}
+
+# Default value for harvester-network-controller-manager deployment
+manager:
+  replicas: 2
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: beta.kubernetes.io/os
+              operator: In
+              values:
+                - linux
+        - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - harvester-network-controller-manager
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - network
+          topologyKey: kubernetes.io/hostname
+        weight: 1


### PR DESCRIPTION
- Migrate harvester network controller chart from [harvester/dependency_charts/harvester-network-controller](https://github.com/harvester/harvester/tree/master/deploy/charts/harvester/dependency_charts/harvester-network-controller) to harvester/charts
- update the CRD to mapping with the master-head version of https://github.com/harvester/network-controller-harvester