### PR TITLE
Add harvester node disk manager chart

### DIFF
--- a/charts/harvester-node-disk-manager/.helmignore
+++ b/charts/harvester-node-disk-manager/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/harvester-node-disk-manager/Chart.yaml
+++ b/charts/harvester-node-disk-manager/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: harvester-node-disk-manager
+description: A Helm chart for Harvester Node Disk Manager
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.0-dev
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.1.0"
+
+maintainers:
+  - name: harvester

--- a/charts/harvester-node-disk-manager/crds/harvesterhci.io_blockdevices.yaml
+++ b/charts/harvester-node-disk-manager/crds/harvesterhci.io_blockdevices.yaml
@@ -1,0 +1,272 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {}
+  creationTimestamp: null
+  name: blockdevices.harvesterhci.io
+spec:
+  group: harvesterhci.io
+  names:
+    kind: BlockDevice
+    listKind: BlockDeviceList
+    plural: blockdevices
+    shortNames:
+    - bd
+    - bds
+    singular: blockdevice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.deviceStatus.details.deviceType
+      name: Type
+      type: string
+    - jsonPath: .status.deviceStatus.fileSystem.mountPoint
+      name: MountPoint
+      type: string
+    - jsonPath: .spec.nodeName
+      name: NodeName
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              devPath:
+                description: a string with the device path of the disk, e.g. "/dev/sda1"
+                type: string
+              fileSystem:
+                properties:
+                  forceFormatted:
+                    description: a bool indicating the device is force formatted to
+                      overwrite the existing one
+                    type: boolean
+                  mountPoint:
+                    description: a string with the partition's mount point, or ""
+                      if no mount point was discovered
+                    type: string
+                  provisioned:
+                    description: a bool indicating whether the filesystem can be provisioned
+                      as a disk for the node to store data.
+                    type: boolean
+                required:
+                - mountPoint
+                type: object
+              nodeName:
+                description: name of the node to which the block device is attached
+                type: string
+            required:
+            - devPath
+            - fileSystem
+            - nodeName
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              deviceStatus:
+                properties:
+                  capacity:
+                    description: a object describe the disk capacity
+                    properties:
+                      physicalBlockSizeBytes:
+                        description: the size of the physical blocks used on the disk,
+                          in bytes
+                        format: int64
+                        type: integer
+                      sizeBytes:
+                        description: the amount of storage the disk provides
+                        format: int64
+                        type: integer
+                    required:
+                    - physicalBlockSizeBytes
+                    - sizeBytes
+                    type: object
+                  details:
+                    description: a object describe the disk details
+                    properties:
+                      busPath:
+                        description: a string represents the block device bus path
+                        type: string
+                      deviceType:
+                        description: a string represents the type of the device, options
+                          are "disk", "part"
+                        enum:
+                        - disk
+                        - part
+                        type: string
+                      driveType:
+                        description: a string represents the type of drive bus, options
+                          are "HDD", "FDD", "ODD", or "SSD", which correspond to a
+                          hard disk drive (rotational), floppy drive, optical (CD/DVD)
+                          drive and solid-state drive
+                        enum:
+                        - HDD
+                        - FDD
+                        - ODD
+                        - SSD
+                        - Unknown
+                        type: string
+                      isRemovable:
+                        description: contains a boolean indicating if the disk drive
+                          is removable
+                        type: boolean
+                      label:
+                        description: a string containing the disk label
+                        type: string
+                      model:
+                        description: a string with the vendor-assigned disk model
+                          name
+                        type: string
+                      numaNodeID:
+                        description: the numeric index of the NUMA node this disk
+                          is local to, or -1
+                        type: integer
+                      partUUID:
+                        description: PartUUID is a partition-table-level UUID for
+                          the partition, a standard feature for all partitions on
+                          GPT-partitioned disks
+                        type: string
+                      ptUUID:
+                        description: PtUUID is the UUID of the partition table itself,
+                          a unique identifier for the entire disk assigned at the
+                          time the disk was partitioned
+                        type: string
+                      serialNumber:
+                        description: a string with the disk's serial number
+                        type: string
+                      storageController:
+                        description: the type of storage controller/drive, options
+                          are "SCSI", "IDE", "virtio", "MMC", or "NVMe"
+                        enum:
+                        - SCSI
+                        - IDE
+                        - virtio
+                        - MMC
+                        - NVMe
+                        - Unknown
+                        type: string
+                      uuid:
+                        description: UUID is a filesystem-level UUID, which is retrieved
+                          from the filesystem metadata inside the partition This would
+                          be volume UUID on macOS, PartUUID on linux, empty on Windows
+                        type: string
+                      vendor:
+                        description: a string with the name of the hardware vendor
+                          for the disk drive
+                        type: string
+                      wwn:
+                        description: a string with the disk's World Wide Name(WWN)
+                        type: string
+                    required:
+                    - deviceType
+                    - driveType
+                    - storageController
+                    type: object
+                  fileSystem:
+                    properties:
+                      LastFormattedAt:
+                        description: the last force formatted timestamp, only exist
+                          when user operate device formatting through the CRD controller
+                        format: date-time
+                        type: string
+                      isReadOnly:
+                        description: a bool indicating the partition is read-only
+                        type: boolean
+                      mountPoint:
+                        description: a string with the partition's mount point, or
+                          "" if no mount point was discovered
+                        type: string
+                      type:
+                        description: a string indicated the filesystem type for the
+                          partition, or "" if the system could not determine the type.
+                        type: string
+                    required:
+                    - mountPoint
+                    - type
+                    type: object
+                  parentDevice:
+                    description: a string with the parent device path of the disk,
+                      e.g. "/dev/sda" e.g `/dev/sda` is the parent for `/dev/sda1`
+                    type: string
+                  partitioned:
+                    description: a bool indicating if the disk is partitioned
+                    type: boolean
+                required:
+                - capacity
+                - details
+                - fileSystem
+                - partitioned
+                type: object
+              state:
+                description: the current state of the block device, options are "Active",
+                  "Inactive", or "Unknown"
+                enum:
+                - Active
+                - Inactive
+                - Unknown
+                type: string
+            required:
+            - state
+            type: object
+        required:
+        - metadata
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/harvester-node-disk-manager/templates/NOTES.txt
+++ b/charts/harvester-node-disk-manager/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The harvester-node-disk-manager has been installed into "{{ .Release.Namespace }}" namespace.

--- a/charts/harvester-node-disk-manager/templates/_helpers.tpl
+++ b/charts/harvester-node-disk-manager/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "harvester-node-disk-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "harvester-node-disk-manager.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "harvester-node-disk-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "harvester-node-disk-manager.labels" -}}
+helm.sh/chart: {{ include "harvester-node-disk-manager.chart" . }}
+{{ include "harvester-node-disk-manager.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "harvester-node-disk-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "harvester-node-disk-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "harvester-node-disk-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "harvester-node-disk-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/harvester-node-disk-manager/templates/daemonset.yaml
+++ b/charts/harvester-node-disk-manager/templates/daemonset.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "harvester-node-disk-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harvester-node-disk-manager.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "harvester-node-disk-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "harvester-node-disk-manager.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "harvester-node-disk-manager.name" . }}
+      hostNetwork: true
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - node-disk-manager
+        env:
+        - name: LONGHORN_NAMESPACE
+          value: {{ .Values.longhornNamespace | default "longhorn-system" }}
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/proc # To access dockerd/containerd mount namespace
+          name: host-proc
+          readOnly: true
+        - mountPath: /run/udev  # To receive udev events
+          name: host-run-udev
+          readOnly: true
+        - mountPath: /dev # To get host device info
+          name: host-dev
+          readOnly: true
+        - mountPath: /sys # To get host sysfs info
+          name: host-sys
+          readOnly: true
+        resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: host-proc
+          hostPath:
+            path: /proc
+            type: Directory
+        - name: host-run-udev
+          hostPath:
+            path: /run/udev
+            type: Directory
+        - name: host-dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: host-sys
+          hostPath:
+            path: /sys
+            type: Directory

--- a/charts/harvester-node-disk-manager/templates/rbac.yaml
+++ b/charts/harvester-node-disk-manager/templates/rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "harvester-node-disk-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "harvester-node-disk-manager.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "harvester-node-disk-manager.name" . }}
+rules:
+  - apiGroups: [ "harvesterhci.io" ]
+    resources: [ "blockdevices" ]
+    verbs: [ "*" ]
+  - apiGroups: [ "longhorn.io" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch", "update", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps", "events" ]
+    verbs: [ "get", "watch", "list", "update", "create" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "harvester-node-disk-manager.name" . }}
+  labels:
+  {{- include "harvester-node-disk-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "harvester-node-disk-manager.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "harvester-node-disk-manager.name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/harvester-node-disk-manager/values.yaml
+++ b/charts/harvester-node-disk-manager/values.yaml
@@ -1,0 +1,46 @@
+# Default values for harvester-node-disk-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: rancher/harvester-node-disk-manager
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "master-head"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+longhornNamespace:


### PR DESCRIPTION
This is the very first version of helm chart for harvester/node-disk-manager. The node-disk manager ~~is still under construction and the API group might change to harvesterhci.io in the near future~~. But IMO the chart itself is worth a check now (to make sure I didn't go too far away.)

Edited:

- There is already an image on docker hub:https://hub.docker.com/r/rancher/harvester-node-disk-manager
- The API group migrations is done (harvester/node-disk-manager#1)