### PR TITLE
update CSI component images in harvester-csi-driver chart

### DIFF
--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         - args:
             - --v=5
             - --csi-address=$(ADDRESS)
-            - --csiTimeout=2m5s
+            - --timeout=1m50s
             - --leader-election
             - --leader-election-namespace=$(POD_NAMESPACE)
           env:
@@ -41,9 +41,8 @@ spec:
         - args:
             - --v=5
             - --csi-address=$(ADDRESS)
-            - --timeout=2m5s
-            - --enable-leader-election
-            - --leader-election-type=leases
+            - --timeout=1m50s
+            - --leader-election
             - --leader-election-namespace=$(POD_NAMESPACE)
           env:
             - name: ADDRESS
@@ -62,7 +61,7 @@ spec:
         - args:
             - --v=5
             - --csi-address=$(ADDRESS)
-            - --timeout=2m5s
+            - --timeout=1m50s
             - --leader-election
             - --leader-election-namespace=$(POD_NAMESPACE)
           env:

--- a/charts/harvester-csi-driver/values.yaml
+++ b/charts/harvester-csi-driver/values.yaml
@@ -9,17 +9,17 @@ image:
       tag: "master-head"
   csi:
     nodeDriverRegistrar:
-      repository: longhornio/csi-node-driver-registrar
-      tag: v1.2.0-lh1
+      repository: rancher/longhornio-csi-node-driver-registrar
+      tag: v2.3.0
     resizer:
-      repository: longhornio/csi-resizer
-      tag: v0.5.1-lh1
+      repository: rancher/longhornio-csi-resizer
+      tag: v1.2.0
     provisioner:
-      repository: longhornio/csi-provisioner
-      tag: v1.6.0-lh1
+      repository: rancher/longhornio-csi-provisioner
+      tag: v2.1.2
     attacher:
-      repository: longhornio/csi-attacher
-      tag: v2.2.1-lh1
+      repository: rancher/longhornio-csi-attacher
+      tag: v3.2.1
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Update images to newer versions that Longhorn v1.2.0 is using.