### PR TITLE
Set default fsType to EXT4

### DIFF
--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -64,6 +64,7 @@ spec:
             - --timeout=1m50s
             - --leader-election
             - --leader-election-namespace=$(POD_NAMESPACE)
+            - --default-fstype=ext4
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
If fstype is not set as a parameter in the storageClass then default to ext4 to ensure volume permissions are configured correctly.

https://github.com/harvester/harvester/issues/1369