### PR TITLE
Fix helper image arg CI error

### DIFF
--- a/charts/harvester-network-controller/templates/deployment.yaml
+++ b/charts/harvester-network-controller/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             {{- if .Values.vipEnabled}}
             - --enable-vip-controller
             {{- end }}
-            - --helper-image={{ printf "%s:%s" .Values.helper.image.repository .Values.helper.image.tag | default .Chart.AppVersion }}
+            - --helper-image={{ printf "%s:%s" .Values.helper.image.repository (.Values.helper.image.tag | default .Chart.AppVersion) }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:


### PR DESCRIPTION
https://github.com/harvester/charts/runs/4405789084?check_suite_focus=true
Fix the error found by CI
```
Error: unable to build kubernetes objects from release manifest: error
validating "": error validating data:
ValidationError(Deployment.spec.template.spec.containers[0].args[1]):
invalid type for io.k8s.api.core.v1.Container.args: got "map", expected
"string" 968
```