### PR TITLE
Remove unused `status.state` from blockdevices

### DIFF
--- a/charts/harvester-node-disk-manager/templates/crds/harvesterhci.io_blockdevices.yaml
+++ b/charts/harvester-node-disk-manager/templates/crds/harvesterhci.io_blockdevices.yaml
@@ -32,8 +32,8 @@ spec:
     - jsonPath: .spec.nodeName
       name: NodeName
       type: string
-    - jsonPath: .status.state
-      name: Status
+    - jsonPath: .status.provisionPhase
+      name: ProvisionPhase
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -256,17 +256,8 @@ spec:
                 - Unprovisioned
                 - Unprovisioning
                 type: string
-              state:
-                description: the current state of the block device, options are "Active",
-                  "Inactive", or "Unknown"
-                enum:
-                - Active
-                - Inactive
-                - Unknown
-                type: string
             required:
             - provisionPhase
-            - state
             type: object
         required:
         - metadata


### PR DESCRIPTION
Related: harvester/node-disk-manager#32

Signed-off-by: Weihang Lo <weihang.lo@suse.com>