### PR TITLE
Remove CPI cluster name question

### DIFF
--- a/charts/harvester-cloud-provider/questions.yml
+++ b/charts/harvester-cloud-provider/questions.yml
@@ -9,9 +9,3 @@ questions:
   group: "Default"
   type: string
   default: "/etc/kubernetes/cloud-config"
-- variable: clusterName
-  label: Cluster name
-  description: "Cluster name"
-  group: "Default"
-  type: string
-  default: ""

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -24,8 +24,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --cloud-config=/etc/kubernetes/cloud-config
-            {{- if ne .Values.clusterName "" }}
-            - --cluster-name={{ .Values.clusterName }}
+            {{- if ne .Values.global.cattle.clusterName "" }}
+            - --cluster-name={{ .Values.global.cattle.clusterName }}
           {{- end }}
           command:
             - harvester-cloud-provider

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -10,7 +10,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "master-head"
 
-clusterName: ""
 cloudConfigPath: "/etc/kubernetes/cloud-config"
 
 imagePullSecrets: []
@@ -69,3 +68,4 @@ affinity:
 global:
   cattle:
     systemDefaultRegistry: ""
+    clusterName: ""


### PR DESCRIPTION
- https://github.com/harvester/harvester/issues/2031

According to UI code, `clusterName` will auto-set to the request body.  Other auto-set fields can refer to these [code](https://github.com/rancher/dashboard/blob/cbdcf7107e10d8e725ec9bdd510084c9ae545877/pages/c/_cluster/apps/charts/install.vue#L807-L813) 。

Change `Values.clusterName` to `Values.global.cattle.clusterName`

