### PR TITLE
fix annotations kube-version and rancher-version

### DIFF
--- a/charts/harvester-cloud-provider/Chart.yaml
+++ b/charts/harvester-cloud-provider/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,13 +31,13 @@ annotations:
   catalog.cattle.io/release-name: harvester-cloud-provider
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux
-  catalog.cattle.io/rancher-version: ">= 2.6.1-0 < 2.7.0-0"
+  catalog.cattle.io/rancher-version: ">= 2.6.1-0 < 2.8.0-0"
   catalog.cattle.io/ui-component: harvester-cloud-provider
   catalog.cattle.io/display-name: Harvester Cloud Provider
   # A SemVer range of compatible Kubernetes versions, just like Helm's kubeVersion.
   # The difference is that ours will only hide the chart in the dashboard UI, and still
   # allow users to edit (helm upgrade) the chart; the helm's kubeVersion disables edit in installed charts.
-  catalog.cattle.io/kube-version: ">= 1.18.0-0 < 1.24.0-0"
+  catalog.cattle.io/kube-version: ">= 1.18.0-0 < 1.26.0-0"
 
 
 maintainers:


### PR DESCRIPTION
Signed-off-by: Chris Ho <chris.he@suse.com>

Dependency version scope change, but failed to generate charts due to patch file.

```bash
> ./bin/charts-build-scripts prepare --package harvester/harvester-cloud-provider
INFO[0000] Pulling https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.1.13/harvester-cloud-provider-0.1.13.tgz from upstream into charts 
INFO[0002] Loading dependencies for chart               
INFO[0002] Applying changes from generated-changes      
INFO[0002] Applying: generated-changes/patch/Chart.yaml.patch 
ERRO[0002] 
patching file Chart.yaml
Hunk #1 FAILED at 1.
1 out of 1 hunk FAILED -- saving rejects to file Chart.yaml.rej 
FATA[0002] encountered error while preparing main chart: encountered error while trying to apply changes to charts: unable to generate patch with error: exit status 1 

```

Related patch file:  https://github.com/rancher/charts/blob/dev-v2.6/packages/harvester/harvester-cloud-provider/generated-changes/patch/Chart.yaml.patch