### PR TITLE
pcidevices: fix for service yaml

### DIFF
--- a/charts/harvester-pcidevices-controller/Chart.yaml
+++ b/charts/harvester-pcidevices-controller/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0-dev
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.1"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-pcidevices-controller/Chart.yaml
+++ b/charts/harvester-pcidevices-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0-dev
+version: 0.1.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/harvester-pcidevices-controller/templates/daemonset.yaml
+++ b/charts/harvester-pcidevices-controller/templates/daemonset.yaml
@@ -21,7 +21,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostNetwork: true
       serviceAccountName: {{ include "harvester-pcidevices-controller.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -69,3 +68,16 @@ spec:
         hostPath:
           path: /lib/modules
           type: Directory
+apiVersion: v1
+kind: Service
+metadata:
+  name: pcidevices-webhook
+  labels:
+    {{- include "harvester-pcidevices-controller.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "harvester-pcidevices-controller.selectorLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: 8443
+      targetPort: 8443

--- a/charts/harvester-pcidevices-controller/templates/daemonset.yaml
+++ b/charts/harvester-pcidevices-controller/templates/daemonset.yaml
@@ -68,16 +68,3 @@ spec:
         hostPath:
           path: /lib/modules
           type: Directory
-apiVersion: v1
-kind: Service
-metadata:
-  name: pcidevices-webhook
-  labels:
-    {{- include "harvester-pcidevices-controller.labels" . | nindent 4 }}
-spec:
-  selector:
-    {{- include "harvester-pcidevices-controller.selectorLabels" . | nindent 4 }}
-  ports:
-    - protocol: TCP
-      port: 8443
-      targetPort: 8443

--- a/charts/harvester-pcidevices-controller/templates/service.yaml
+++ b/charts/harvester-pcidevices-controller/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pcidevices-webhook
+  labels:
+    {{- include "harvester-pcidevices-controller.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "harvester-pcidevices-controller.selectorLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: 8443
+      targetPort: 8443

--- a/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
+++ b/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
@@ -27,6 +27,12 @@ rules:
   - apiGroups: [ "devices.harvesterhci.io" ]
     resources: [ "pcidevices", "pcidevices/status", "pcideviceclaims", "pcideviceclaims/status" ]
     verbs: [ "get", "watch", "list", "update", "create", "delete"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: [ "get", "watch", "list", "update", "create", "delete" ]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: [ "get", "watch", "list", "update", "create", "delete" ]   
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Change splits daemonset.yaml and puts service definition in a separate file for better readability,.