### PR TITLE
pci-device-controller: increase resource limit

### DIFF
--- a/charts/harvester-pcidevices-controller/values.yaml
+++ b/charts/harvester-pcidevices-controller/values.yaml
@@ -38,11 +38,11 @@ service:
 
 resources:
   limits:
-    cpu: 20m
-    memory: 100Mi
+    cpu: 50m
+    memory: 300Mi
   requests:
-    cpu: 10m
-    memory: 50Mi
+    cpu: 20m
+    memory: 200Mi
 
 
 nodeSelector: {}


### PR DESCRIPTION
We hit OOM with the previous value and observe the average MEM use for 4-node clusters is between 150 to 200.
The CPU limit is also increased a little bit and we can fine-tune later.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>