### PR TITLE
fix: disable importer pvc by default

### DIFF
--- a/charts/harvester-vm-import-controller/templates/deployment.yaml
+++ b/charts/harvester-vm-import-controller/templates/deployment.yaml
@@ -50,5 +50,9 @@ spec:
       {{- end }}
       volumes:
       - name: storage
+{{- if .Values.pvcClaim.enabled }}
         persistentVolumeClaim:
           claimName: {{ include "vm-import-controller.fullname" . }}
+{{- else }}
+        emptyDir: {}
+{{- end }}

--- a/charts/harvester-vm-import-controller/templates/pvc.yaml
+++ b/charts/harvester-vm-import-controller/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pvcClaim.enabled -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -17,5 +18,6 @@ spec:
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.pvcClaim.storageClass }}"
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/harvester-vm-import-controller/values.yaml
+++ b/charts/harvester-vm-import-controller/values.yaml
@@ -53,6 +53,7 @@ resources:
     memory: "4Gi"
 
 pvcClaim:
+  enabled: false
   size: "200Gi"
   # leave empty to use longhorn default
   storageClassName: ""


### PR DESCRIPTION
**Description:**
disable `vm-importer` PVC by default so it won't run over the Harvester minimum storage request.

