### PR TITLE
rbac update for pcidevices chart

### DIFF
--- a/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
+++ b/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
@@ -36,6 +36,9 @@ rules:
   - apiGroups: ["kubevirt.io"]
     resources: ["kubevirts"]
     verbs: [ "get", "update" ]
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachines"]
+    verbs: [ "get", "list", "watch" ]    
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
PR introduces changes for rbac update to pcidevices helm chart to allow webhook to access VirtualMachines in kubevirt.io api group.