### PR TITLE
Fix permissions for the mgmt interface filtering

### DIFF
--- a/charts/harvester-pcidevices-controller/templates/daemonset.yaml
+++ b/charts/harvester-pcidevices-controller/templates/daemonset.yaml
@@ -35,6 +35,8 @@ spec:
           args:
             - agent
           volumeMounts:
+            - mountPath: /var/lib/kubelet/device-plugins
+              name: device-plugins
             - mountPath: /lib/modules
               name: modules
             - mountPath: /sys
@@ -60,6 +62,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: Directory
+          name: device-plugins
         - hostPath:
             path: /lib/modules
             type: Directory

--- a/charts/harvester-pcidevices-controller/templates/daemonset.yaml
+++ b/charts/harvester-pcidevices-controller/templates/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         {{- include "harvester-pcidevices-controller.selectorLabels" . | nindent 8 }}
     spec:
+      hostNetwork: true
+      hostPID: true
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/harvester-pcidevices-controller/templates/daemonset.yaml
+++ b/charts/harvester-pcidevices-controller/templates/daemonset.yaml
@@ -18,7 +18,6 @@ spec:
         {{- include "harvester-pcidevices-controller.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: true
-      hostPID: true
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -42,6 +41,8 @@ spec:
             - mountPath: /sys
               name: sys
           env:
+            - name: GHW_DISABLE_WARNINGS
+              value: "1"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Test

The [change to pcidevices](https://github.com/harvester/pcidevices/commit/4bf9e47f08b34729ef075f04e35fc7e204b5fd95) that filters out the management interface was merged, but it depends on a change to the daemonset that gives the pod permission to access the host network and the host PID information. 

I tested this by running `kubectl edit daemonsets.apps -n harvester-system harvester-pcidevices-controller`

And editing these in: 

```yaml
spec:
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/instance: pcidevices-controller
      app.kubernetes.io/name: harvester-pcidevices-controller
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: pcidevices-controller
        app.kubernetes.io/name: harvester-pcidevices-controller
    spec:
      hostNetwork: true
      hostPID: true
      containers:
```