### PR TITLE
pcidevices controller helm rbac update

### DIFF
--- a/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
+++ b/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
@@ -29,7 +29,7 @@ rules:
     verbs: [ "get", "watch", "list", "update", "create", "delete"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]
-    verbs: [ "get", "watch", "list", "update", "create", "delete" ]
+    verbs: [ "get", "watch", "list", "update", "create", "delete", "patch" ]
   - apiGroups: ["apiregistration.k8s.io"]
     resources: ["apiservices"]
     verbs: [ "get", "watch", "list", "update", "create", "delete" ]
@@ -39,6 +39,9 @@ rules:
   - apiGroups: ["kubevirt.io"]
     resources: ["virtualmachines"]
     verbs: [ "get", "list", "watch" ]    
+  - apiGroups: ["network.harvesterhci.io"]
+    resources: ["vlanconfigs"]
+    verbs: [ "get", "list", "watch" ]      
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
additional permissions for harvester-pcidevices-controller cluster role to allow it to watch vlanconfigs