### PR TITLE
updates for pcidevices controller

### DIFF
--- a/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
+++ b/charts/harvester-pcidevices-controller/templates/serviceaccount.yaml
@@ -44,7 +44,7 @@ rules:
     verbs: [ "get", "list", "watch" ]      
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: [ "get", "list", "watch" ]
+    verbs: [ "get", "list", "watch", "create", "update" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Minor change to allow pcidevices controller service account to be able to create/update leases.coordination objects.