### PR TITLE
Remove use of deprecated label

### DIFF
--- a/charts/harvester-network-controller/values.yaml
+++ b/charts/harvester-network-controller/values.yaml
@@ -37,11 +37,6 @@ manager:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: beta.kubernetes.io/os
-              operator: In
-              values:
-                - linux
-        - matchExpressions:
             - key: kubernetes.io/os
               operator: In
               values:


### PR DESCRIPTION
Before:

	$ helm package .
	Successfully packaged chart and saved it to: /.../charts/charts/harvester-network-controller/harvester-network-controller-0.3.2.tgz

	$ helm upgrade --dry-run -n harvester-system harvester harvester-network-controller-0.3.2.tgz | grep beta\.kubernetes\.io\/os | wc -l
	1

After:

	$ helm package .
	Successfully packaged chart and saved it to: /.../charts/charts/harvester-network-controller/harvester-network-controller-0.3.2.tgz

	$ helm upgrade --dry-run -n harvester-system harvester harvester-network-controller-0.3.2.tgz | grep beta\.kubernetes\.io\/os | wc -l
	0

Related-to: https://github.com/harvester/harvester/issues/2899