### PR TITLE
Use the kube-vip mirrored image instead

### DIFF
--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -73,7 +73,7 @@ global:
 kube-vip:
   enabled: true
   image:
-    repository: plndr/kube-vip-iptables
+    repository: rancher/mirrored-kube-vip-kube-vip-iptables
     tag: v0.6.0
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"


### PR DESCRIPTION
Use the kube-vip mirrored image instead of the official image because of the requirement from RKE2.

Related issue: https://github.com/rancher/rke2/issues/4184