### PR TITLE
updates for harvester-seeder to support webhook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,10 @@ jobs:
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Create harvester-system namespace
+        run: "kubectl create namespace harvester-system"
+        if: steps.list-changed.outputs.changed == 'true'
+
       - name: Run chart-testing (install)
         run: ct install --config tests/ct.yaml
 

--- a/charts/harvester-seeder/Chart.yaml
+++ b/charts/harvester-seeder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0-dev
+version: 0.0.1-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,4 +24,4 @@ version: 0.0.0-dev
 appVersion: v0.1.0
 
 maintainers:
-- name: harvester
+  - name: harvester

--- a/charts/harvester-seeder/templates/deployment.yaml
+++ b/charts/harvester-seeder/templates/deployment.yaml
@@ -53,7 +53,10 @@ spec:
               protocol: TCP
             - name: leader
               containerPort: 9443
-              protocol: TCP     
+              protocol: TCP
+            - name: webhook
+              containerPort: 443
+              protocol: TCP         
           livenessProbe:
             httpGet:
               path: /metrics

--- a/charts/harvester-seeder/templates/rbac.yaml
+++ b/charts/harvester-seeder/templates/rbac.yaml
@@ -23,6 +23,8 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
 - apiGroups:
   - bmc.tinkerbell.org
   resources:
@@ -82,6 +84,29 @@ rules:
     - events
   verbs:
     - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - create
+  - delete
+  - patch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/harvester-seeder/templates/service.yaml
+++ b/charts/harvester-seeder/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: 443
+      targetPort: webhook
+      protocol: TCP
+      name: webhook
   selector:
     {{- include "seeder.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
PR introduces changes for harvester-seeder to support newly introduced webhook for validating inventory objects.

harvester-seeder PR dependent on this: https://github.com/harvester/seeder/pull/17