### PR TITLE
Update node-manager version and tolerations

### DIFF
--- a/charts/harvester-node-manager/Chart.yaml
+++ b/charts/harvester-node-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.1.5
+appVersion: v0.1.6
 
 maintainers:
   - name: harvester

--- a/charts/harvester-node-manager/values.yaml
+++ b/charts/harvester-node-manager/values.yaml
@@ -18,5 +18,7 @@ resources:
 tolerations:
   # this toleration is to have the daemonset runnable on master nodes
   # remove it if your masters can't run pods
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  - effect: NoExecute
+    operator: Exists


### PR DESCRIPTION
To make the node-manager run on the `etcd` node, we need to update tolerations.