### PR TITLE
chart: bump harvester-csi-driver v0.1.17

### DIFF
--- a/charts/harvester-csi-driver/Chart.yaml
+++ b/charts/harvester-csi-driver/Chart.yaml
@@ -18,12 +18,12 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.1.5
+appVersion: v0.1.6
 
 maintainers:
   - name: harvester


### PR DESCRIPTION
    - appVersion to v0.1.6
    v0.1.6 contains a new checking mechanism if
    the guest VM has a different naming style.
