### PR TITLE
fix: add kube-vip toleration to match node taint in harvester-cloud-provider

### DIFF
--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -72,6 +72,13 @@ global:
 
 kube-vip:
   enabled: true
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
+    operator: Exists
   image:
     repository: rancher/mirrored-kube-vip-kube-vip-iptables
     tag: v0.6.0


### PR DESCRIPTION
## Description

After setting up guest cluster with this configuration (control-plane + ETCD separate from worker in different pool)  mentioned in Test Plan. 

When you create load balancer type service with harvester cloud provider annotation, the load balancer type service `EXTERNAL_IP` is stuck in pending status 

After discussion in https://github.com/harvester/harvester/issues/4678, the reason is `kube-vip` toleration doesn't matched any node taint.

## Solution

Add one more toleration in `kube-vip` DaemonSet. It should works in all cases listed in Test Plan.

Bump PR is https://github.com/harvester/charts/pull/203

##  Issue

https://github.com/harvester/harvester/issues/4678

## Test Plan

### Common set up

1. We choose harvester cloud provider. 
    ![image](https://github.com/harvester/charts/assets/6960289/71c77a9c-6e3f-457c-a244-9efacd14d18a)
2. Set up cloud-config in each node for later usage because we need to reinstall harvester-cloud-provider manually
```yaml
write_files:
  - encoding: b64
    content: {harvester's kube config, the cluster namespace should be same as the pool you created (base64 enconded)}
    owner: root:root
    path: /etc/kubernetes/cloud-config
    permission: '0644'
```
3. After pools are created, we remove the harvester-cloud-provider in Apps > Installed Apps (kube-system namesapce).
    ![image](https://github.com/harvester/charts/assets/6960289/782e78ac-364c-4321-850e-fa689c934500)
4. We add new charts in Apps > Repositories.
    Currently, I use my repository to build it and test it (https://yu-jack.github.io/charts/). 
    
    ![image](https://github.com/harvester/charts/assets/6960289/c1f9a7d7-8e88-46b6-9953-597aa285cfd5)
    
    Please choose 0.2.7 instead 0.2.3 because I'm testing something and remove it.
    
    ![image](https://github.com/harvester/charts/assets/6960289/8c6d817a-dccc-4a61-b1d1-cb455d28eb2e)
5. Go to Apps > Charts to install harvester-cloud-provider

### Different Guest Cluster Pool

1. control-plane, ETCD and worker in same pool
2. control-plane and ETCD in A pool, worker in B pool
3. control-plane in A pool, ETCD in B pool and worker in C pool

After install harvester-cloud-provider, DaemonSet kube-system/kube-vip should run in above three cases in guest cluster. Then create following load balance type service to check `EXTERNAL_IP` is assigned or not.

![image](https://github.com/harvester/charts/assets/6960289/4ed16596-89ff-4503-889e-6df83319e55e)

```yaml
# example svc
apiVersion: v1
kind: Service
metadata:
  name: helloworldserver-lb
  annotations:
    cloudprovider.harvesterhci.io/ipam: dhcp
    cloudprovider.harvesterhci.io/healthcheck-port: "80"
spec:
  type: LoadBalancer
  selector:
    app: web
  ports:
    - name: test
      protocol: TCP
      port: 8088
      targetPort: 80
```

