### PR TITLE
charts: bump harvester-cloud-provider 0.2.3

### DIFF
--- a/charts/harvester-cloud-provider/Chart.yaml
+++ b/charts/harvester-cloud-provider/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -72,6 +72,13 @@ global:
 
 kube-vip:
   enabled: true
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
+    operator: Exists
   image:
     repository: rancher/mirrored-kube-vip-kube-vip-iptables
     tag: v0.6.0


### PR DESCRIPTION
according to updating https://github.com/harvester/charts/pull/202, bump harvester-cloud-provider version.