### PR TITLE
harvester-node-manager: update RBAC for eventing

### DIFF
--- a/charts/harvester-node-manager/templates/rbac.yaml
+++ b/charts/harvester-node-manager/templates/rbac.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "nodes" ]
     verbs: [ "get", "watch", "list", "update" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "create", "get", "list", "update" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
- [x] Depends on: https://github.com/harvester/node-manager/pull/15

A new controller in harvester-node-manager emits events whenever it modifies one of the files under its management. In order to do so successfully, it needs the capability added to the node-manager chart RBAC.
