### PR TITLE
Bump node-manager chart and appVersion to v0.2.0

### DIFF
--- a/charts/harvester-node-manager/Chart.yaml
+++ b/charts/harvester-node-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.1.6
+appVersion: v0.2.0
 
 maintainers:
   - name: harvester

--- a/charts/harvester-node-manager/templates/_helpers.tpl
+++ b/charts/harvester-node-manager/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "harvester-node-manager-webhook.name" -}}
+{{- default "harvester-node-manager-webhook" | trunc 63 }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -31,4 +35,17 @@ Selector labels
 {{- define "harvester-node-manager.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "harvester-node-manager.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "harvester-node-manager-webhook.labels" -}}
+helm.sh/chart: {{ include "harvester-node-manager.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: node-manager
+{{- end }}
+
+{{- define "harvester-node-manager-webhook.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "harvester-node-manager-webhook.name" . }}
 {{- end }}

--- a/charts/harvester-node-manager/templates/crds/node.harvesterhci.io_cloudinits.yaml
+++ b/charts/harvester-node-manager/templates/crds/node.harvesterhci.io_cloudinits.yaml
@@ -1,0 +1,148 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {}
+  creationTimestamp: null
+  name: cloudinits.node.harvesterhci.io
+spec:
+  group: node.harvesterhci.io
+  names:
+    kind: CloudInit
+    listKind: CloudInitList
+    plural: cloudinits
+    shortNames:
+    - nci
+    singular: cloudinit
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              contents:
+                type: string
+              filename:
+                type: string
+              matchSelector:
+                additionalProperties:
+                  type: string
+                type: object
+              paused:
+                type: boolean
+            required:
+            - contents
+            - filename
+            - matchSelector
+            type: object
+          status:
+            properties:
+              rollouts:
+                additionalProperties:
+                  properties:
+                    conditions:
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  type: object
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/harvester-node-manager/templates/deployment.yaml
+++ b/charts/harvester-node-manager/templates/deployment.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "harvester-node-manager-webhook.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harvester-node-manager-webhook.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "harvester-node-manager-webhook.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.webhook.replicas }}
+  template:
+    metadata:
+      labels:
+        {{- include "harvester-node-manager-webhook.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "harvester-node-manager-webhook.name" . }}
+      containers:
+        - name: harvester-node-manager-webhook
+          image: "{{ .Values.webhook.image.repository}}:{{ .Values.webhook.image.tag }}"
+          imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
+          ports:
+          - containerPort: 8443
+            name: https
+            protocol: TCP
+          env:
+            - name: WEBHOOK_SERVER_HTTPS_PORT
+              value: "8443"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}

--- a/charts/harvester-node-manager/templates/rbac.yaml
+++ b/charts/harvester-node-manager/templates/rbac.yaml
@@ -35,3 +35,47 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "harvester-node-manager.name" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "harvester-node-manager-webhook.labels" . | nindent 4 }}
+  name: {{ include "harvester-node-manager-webhook.name" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "harvester-node-manager-webhook.name" . }}
+rules:
+  - apiGroups: [ "node.harvesterhci.io" ]
+    resources: [ "*" ]
+    verbs: [ "get", "watch", "list" ]
+  - apiGroups: [ "" ]
+    resources: [ "secrets", "configmaps" ]
+    verbs: [ "get", "watch", "list", "update", "create" ]
+  - apiGroups: [ "apiregistration.k8s.io" ]
+    resources: [ "apiservices"]
+    verbs: [ "get", "watch", "list" ]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: [ "get", "watch", "list" ]
+  - apiGroups: [ "admissionregistration.k8s.io" ]
+    resources: [ "validatingwebhookconfigurations", "mutatingwebhookconfigurations" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "harvester-node-manager-webhook.labels" . | nindent 4 }}
+  name: {{ include "harvester-node-manager-webhook.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "harvester-node-manager-webhook.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "harvester-node-manager-webhook.name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/harvester-node-manager/templates/rbac.yaml
+++ b/charts/harvester-node-manager/templates/rbac.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "nodes" ]
     verbs: [ "get", "watch", "list", "update" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "create", "get", "list", "update" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/harvester-node-manager/templates/service.yaml
+++ b/charts/harvester-node-manager/templates/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "harvester-node-manager-webhook.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "harvester-node-manager-webhook.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443

--- a/charts/harvester-node-manager/values.yaml
+++ b/charts/harvester-node-manager/values.yaml
@@ -22,3 +22,10 @@ tolerations:
     key: node-role.kubernetes.io/master
   - effect: NoExecute
     operator: Exists
+
+webhook:
+  replicas: 3
+  image:
+    repository: rancher/harvester-node-manager-webhook
+    pullPolicy: Always
+    tag: "master-head"


### PR DESCRIPTION
- Chart template updated.
  - https://github.com/harvester/charts/pull/205
  - https://github.com/harvester/charts/pull/206
- And a new image tag: https://github.com/harvester/node-manager/releases/tag/v0.2.0