### PR TITLE
Use scale-available annotation for node-manager webhook

### DIFF
--- a/charts/harvester-node-manager/templates/deployment.yaml
+++ b/charts/harvester-node-manager/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harvester-node-manager-webhook.labels" . | nindent 4 }}
+  {{- with .Values.webhook.replicas }}
+  annotations:
+    management.cattle.io/scale-available: "{{ . }}"
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

If the Helm chart is installed with more replicas than there are nodes, there will be redundant harvester-node-manager-webhook pods running on a single node.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Use the `management.cattle.io/scale-available` annotation to grow/reduce the number of replicas when nodes are added/removed.

**Related Issue:** https://github.com/harvester/harvester/issues/5149

**Test plan:**

1. Start with a single node cluster, install the Helm chart with `--set webhook.replicas=3` (this is the default value)
2. Assert there is only 1 replica (`kubectl get pods -n harvester-system | grep harvester-node-manager-webhook | grep Running | wc -l`)
3. Add an agent node
4. Assert that there are 2 replicas (`kubectl get pods -n harvester-system | grep harvester-node-manager-webhook | grep Running | wc -l`)
5. Add a third node
6. Assert that there are now 3 replicas (`kubectl get pods -n harvester-system | grep harvester-node-manager-webhook | grep Running | wc -l`)

