### PR TITLE
feat(crd): update vm-dhcp-controller crd manifests

### DIFF
--- a/charts/harvester-vm-dhcp-controller/crds/network.harvesterhci.io_ippools.yaml
+++ b/charts/harvester-vm-dhcp-controller/crds/network.harvesterhci.io_ippools.yaml
@@ -66,9 +66,14 @@ spec:
                 properties:
                   cidr:
                     type: string
+                    x-kubernetes-validations:
+                    - message: CIDR is immutable
+                      rule: self == oldSelf
                   dns:
+                    format: ipv4
                     items:
                       type: string
+                    maxItems: 3
                     type: array
                   domainName:
                     type: string
@@ -81,35 +86,83 @@ spec:
                   ntp:
                     items:
                       type: string
+                    maxItems: 4
                     type: array
                   pool:
                     properties:
                       end:
+                        format: ipv4
                         type: string
+                        x-kubernetes-validations:
+                        - message: End is immutable
+                          rule: self == oldSelf
                       exclude:
+                        format: ipv4
                         items:
                           type: string
                         type: array
+                        x-kubernetes-validations:
+                        - message: Exclude is immutable
+                          rule: self == oldSelf
                       start:
+                        format: ipv4
                         type: string
+                        x-kubernetes-validations:
+                        - message: Start is immutable
+                          rule: self == oldSelf
+                    required:
+                    - end
+                    - start
                     type: object
+                    x-kubernetes-validations:
+                    - message: End is required once set
+                      rule: '!has(oldSelf.exclude) || has(self.exclude)'
                   router:
+                    format: ipv4
                     type: string
+                    x-kubernetes-validations:
+                    - message: Router is immutable
+                      rule: self == oldSelf
                   serverIP:
+                    format: ipv4
                     type: string
+                    x-kubernetes-validations:
+                    - message: ServerIP is immutable
+                      rule: self == oldSelf
+                required:
+                - cidr
+                - pool
+                - serverIP
                 type: object
+                x-kubernetes-validations:
+                - message: Router is required once set
+                  rule: '!has(oldSelf.router) || has(self.router)'
               networkName:
+                maxLength: 64
                 type: string
+                x-kubernetes-validations:
+                - message: NetworkName is immutable
+                  rule: self == oldSelf
               paused:
                 type: boolean
+            required:
+            - networkName
             type: object
           status:
             properties:
               agentPodRef:
                 properties:
+                  image:
+                    type: string
                   name:
                     type: string
                   namespace:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
                     type: string
                 type: object
               conditions:
@@ -161,4 +214,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}

--- a/charts/harvester-vm-dhcp-controller/crds/network.harvesterhci.io_virtualmachinenetworkconfigs.yaml
+++ b/charts/harvester-vm-dhcp-controller/crds/network.harvesterhci.io_virtualmachinenetworkconfigs.yaml
@@ -50,21 +50,37 @@ spec:
             type: object
           spec:
             properties:
-              networkConfig:
+              networkConfigs:
                 items:
                   properties:
                     ipAddress:
+                      format: ipv4
                       type: string
                     macAddress:
+                      maxLength: 17
                       type: string
                     networkName:
+                      maxLength: 64
                       type: string
+                  required:
+                  - macAddress
+                  - networkName
                   type: object
+                maxItems: 4
                 type: array
+                x-kubernetes-validations:
+                - message: NetworkConfig may only be added
+                  rule: oldSelf.all(x, x in self)
               paused:
                 type: boolean
               vmName:
+                maxLength: 64
                 type: string
+                x-kubernetes-validations:
+                - message: VMName is immutable
+                  rule: self == oldSelf
+            required:
+            - vmName
             type: object
           status:
             properties:
@@ -96,7 +112,7 @@ spec:
                   - type
                   type: object
                 type: array
-              networkConfig:
+              networkConfigs:
                 items:
                   properties:
                     allocatedIPAddress:
@@ -113,4 +129,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}


### PR DESCRIPTION
Add declarative validations and some additional fields to support agent upgrades

Ref:

- harvester/vm-dhcp-controller#18
- harvester/vm-dhcp-controller#23