### PR TITLE
node-manager-webhook: Use node-manager tolerations

### DIFF
--- a/charts/harvester-node-manager/templates/deployment.yaml
+++ b/charts/harvester-node-manager/templates/deployment.yaml
@@ -34,3 +34,7 @@ spec:
               value: "8443"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The harvester-node-manager-webhook is not scheduled on witness nodes, so when the deployment is auto-scaled, it can result in redundant pods on one node.

```console
harv1:~ # kubectl get nodes
NAME    STATUS   ROLES                       AGE   VERSION
etcd1   Ready    <none>                      47m   v1.27.10+rke2r1
harv1   Ready    control-plane,etcd,master   18h   v1.27.10+rke2r1

harv1:~ # kubectl get pods -n harvester-system -o=custom-columns='NAME:.metadata.name,NODE:spec.nodeName' | grep node-manager-webhook
harvester-node-manager-webhook-6b8cfcbc7b-lnhhc         harv1
harvester-node-manager-webhook-6b8cfcbc7b-pk5wl         harv1
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Since the node-manager daemonset requires the node-manager-webhook to function properly, use the node-manager's tolerations to ensure that the webhook shares availability characteristics with the daemonset.

**Related Issue:** https://github.com/harvester/harvester/issues/5210

**Test plan:**

1. Leave harvester-node-manager-webhook replicas set to the default value of 3
2. Your Harvester cluster has 2 nodes, one is a regular control plane node and one is a witness/etcd node
3. Assert that the harvester-node-manager-webhook is scheduled on the witness node


```console
harv1:~ # kubectl get pods -n harvester-system -o=custom-columns='NAME:.metadata.name,NODE:spec.nodeName' | grep node-manager-webhook
harvester-node-manager-webhook-6cdd49c4bd-7wtt6         harv1
harvester-node-manager-webhook-6cdd49c4bd-8fncw         etcd1
```
