### PR TITLE
node-manager-webhook: Defer replica scaling to scale-available annotation

### DIFF
--- a/charts/harvester-node-manager/templates/deployment.yaml
+++ b/charts/harvester-node-manager/templates/deployment.yaml
@@ -14,7 +14,9 @@ spec:
   selector:
     matchLabels:
       {{- include "harvester-node-manager-webhook.selectorLabels" . | nindent 6 }}
+  {{- if not .Values.webhook.replicas }}
   replicas: {{ .Values.webhook.replicas }}
+  {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

If the Helm chart specifies BOTH the `management.cattle.io/scale-available` annotation and .spec.replicas, then the mcc-harvester bundle will be considered Not Ready in clusters where the number of nodes is fewer than .spec.replicas because the management.cattle.io/scale-available scales the replica up/down based on node availability up to the desired count.

This will prevent upgrading the Harvester cluster on a 1 or 2 node cluster when the number of replicas is set to 3.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Defer completely to the management.cattle.io/scale-available annotation instead of specifying .spec.replicas.

**Related Issue:** https://github.com/harvester/harvester/issues/5212

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Assert that the .spec.replicas field is not generated in the Helm chart when .Values.webhook.replicas > 0, and that value is instead only used for the scale-available annotation:

```console
$ helm install --dry-run --generate-name --set webhook.replicas=2 .
```

```yaml
---
# Source: harvester-node-manager/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: harvester-node-manager-webhook
  namespace: default
  labels:
    helm.sh/chart: harvester-node-manager-0.0.0-dev
    app.kubernetes.io/version: "v0.1.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: node-manager
  annotations:
    management.cattle.io/scale-available: "2"
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: harvester-node-manager-webhook
  template:
    metadata:
      labels:
        app.kubernetes.io/name: harvester-node-manager-webhook
    spec:
      serviceAccountName: harvester-node-manager-webhook
      containers:
        - name: harvester-node-manager-webhook
          image: "rancher/harvester-node-manager-webhook:master-head"
          imagePullPolicy: Always
          ports:
          - containerPort: 8443
            name: https
            protocol: TCP
          env:
            - name: WEBHOOK_SERVER_HTTPS_PORT
              value: "8443"
            - name: NAMESPACE
              value: default
```

Assert that the scale-available annotation is not used when webhook.replicas is 0 and instead .spec.replicas is used:

```console
$ helm install --dry-run --generate-name --set webhook.replicas=0 .
```

```yaml
---
# Source: harvester-node-manager/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: harvester-node-manager-webhook
  namespace: default
  labels:
    helm.sh/chart: harvester-node-manager-0.0.0-dev
    app.kubernetes.io/version: "v0.1.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: node-manager
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: harvester-node-manager-webhook
  replicas: 0
  template:
    metadata:
      labels:
        app.kubernetes.io/name: harvester-node-manager-webhook
    spec:
      serviceAccountName: harvester-node-manager-webhook
      containers:
        - name: harvester-node-manager-webhook
          image: "rancher/harvester-node-manager-webhook:master-head"
          imagePullPolicy: Always
          ports:
          - containerPort: 8443
            name: https
            protocol: TCP
          env:
            - name: WEBHOOK_SERVER_HTTPS_PORT
              value: "8443"
            - name: NAMESPACE
              value: default

NOTES:
The harvester-node-manager has been installed into "default" namespace.
```