### PR TITLE
fix: grant node list permission to vm-dhcp-webhook

### DIFF
--- a/charts/harvester-vm-dhcp-controller/templates/rbac.yaml
+++ b/charts/harvester-vm-dhcp-controller/templates/rbac.yaml
@@ -52,7 +52,7 @@ rules:
   resources: [ "ippools", "virtualmachinenetworkconfigs" ]
   verbs: [ "*" ]
 - apiGroups: [ "" ]
-  resources: [ "secrets" ]
+  resources: [ "nodes", "secrets" ]
   verbs: [ "watch", "list" ]
 - apiGroups: [ "k8s.cni.cncf.io" ]
   resources: [ "network-attachment-definitions" ]


### PR DESCRIPTION
The validating admission webhook of vm-dhcp-controller needs to compare the user input cidr with the cluster-wide service cidr. Such information is retrieved from the node objects. So the webhook must have the LIST permission on nodes objects.

Related issue: harvester/harvester#5153
Depends on harvester/vm-dhcp-controller#27