### PR TITLE
fix: add nodeaffinity for kube-vip daemonset

### DIFF
--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -82,8 +82,6 @@ kube-vip:
   image:
     repository: rancher/mirrored-kube-vip-kube-vip-iptables
     tag: v0.6.0
-  nodeSelector:
-    node-role.kubernetes.io/control-plane: "true"
   env:
     vip_interface: ""
     vip_arp: "true"
@@ -94,3 +92,15 @@ kube-vip:
     svc_enable: "true"
     vip_leaderelection: "false"
     enable_service_security: "true"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        # For RKE1
+        - matchExpressions:
+          - key: node-role.kubernetes.io/controlplane
+            operator: Exists
+        # For RKE2
+        - matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists


### PR DESCRIPTION
Since RKE1 and RKE2 have slightly different node label keys:

- RKE1: `node-role.kubernetes.io/controlplane`
- RKE2: `node-role.kubernetes.io/control-plane`

We need to be compatible with both two types of guest cluster deployment, hence moving the nodeSelector to nodeAffinity.

Related issue: harvester/harvester#5247