### PR TITLE
Bump harvester-load-balancer to v0.2.5

### DIFF
--- a/charts/harvester-load-balancer/Chart.yaml
+++ b/charts/harvester-load-balancer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.2.0
+appVersion: v0.2.5
 
 home: https://github.com/harvester/harvester-load-balancer
 

--- a/charts/harvester-load-balancer/values.yaml
+++ b/charts/harvester-load-balancer/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: rancher/harvester-load-balancer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.2.0
+  tag: v0.2.5
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
To fix https://github.com/harvester/harvester/issues/5137, the harvester-load-balancer image has a new v0.2.5 release.

Bump a new chart v0.2.5 release to Harvester.