### PR TITLE
initial commit for harvester pcidevices roles charts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,10 @@ jobs:
         run: "kubectl create namespace harvester-system"
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Create roletemplate crd
+        run: "kubectl create -f tests/roletemplate_crd.yaml"
+        if: steps.list-changed.outputs.changed == 'true'
+                
       - name: Run chart-testing (install)
         run: ct install --config tests/ct.yaml
 

--- a/charts/harvester-pcidevices-roles/Chart.yaml
+++ b/charts/harvester-pcidevices-roles/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: harvester-pcidevices-roles
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"
+maintainers:
+- name: harvester

--- a/charts/harvester-pcidevices-roles/templates/harvester-pcidevices-admin.yaml
+++ b/charts/harvester-pcidevices-roles/templates/harvester-pcidevices-admin.yaml
@@ -1,0 +1,45 @@
+apiVersion: management.cattle.io/v3
+builtin: false
+context: cluster
+description: "Harvester PCIDevices Admin can manage all device resources on downstream Harvester cluster"
+displayName: Harvester PCIDevices ReadOnly Role
+external: false
+hidden: false
+kind: RoleTemplate
+metadata:
+  name: harvester-pcidevices-readonly
+rules:
+- apiGroups:
+  - devices.harvesterhci.io
+  resources:
+  - pcidevices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devices.harvesterhci.io
+  resources:
+  - pcideviceclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - harvesterhci.io
+  resources:
+  - addons
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devices.harvesterhci.io
+  resources:
+  - sriovgpudevices
+  - vgpudevices
+  - sriovnetworkdevices
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/harvester-pcidevices-roles/templates/harvester-pcidevices-readonly.yaml
+++ b/charts/harvester-pcidevices-roles/templates/harvester-pcidevices-readonly.yaml
@@ -1,0 +1,45 @@
+apiVersion: management.cattle.io/v3
+builtin: false
+context: cluster
+description: "Harvester PCIDevices Read Only can view device resources on downstream Harvester cluster"
+displayName: Harvester PCIDevices Admin Role
+external: false
+hidden: false
+kind: RoleTemplate
+metadata:
+  name: harvester-pcidevices-admin
+rules:
+- apiGroups:
+  - devices.harvesterhci.io
+  resources:
+  - pcidevices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devices.harvesterhci.io
+  resources:
+  - pcideviceclaims
+  verbs:
+  - '*'
+- apiGroups:
+  - harvesterhci.io
+  resources:
+  - addons
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devices.harvesterhci.io
+  resources:
+  - sriovgpudevices
+  - vgpudevices
+  - sriovnetworkdevices
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/tests/roletemplate_crd.yaml
+++ b/tests/roletemplate_crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  creationTimestamp: "2023-10-11T02:04:10Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/managed-by: rancher
+  name: roletemplates.management.cattle.io
+  resourceVersion: "6499013"
+  uid: 58760b2c-6813-4a7b-a6b3-d58969104075
+spec:
+  conversion:
+    strategy: None
+  group: management.cattle.io
+  names:
+    kind: RoleTemplate
+    listKind: RoleTemplateList
+    plural: roletemplates
+    singular: roletemplate
+  scope: Cluster
+  versions:
+  - name: v3
+    schema:
+      openAPIV3Schema:
+        description: RoleTemplate holds configuration for a template that is used
+          to create kubernetes Roles and ClusterRoles (in the rbac.authorization.k8s.io
+          group) for a cluster or project.
+        properties:
+          administrative:
+            description: Administrative if false, and context is set to cluster this
+              RoleTemplate will not grant access to "CatalogTemplates" and "CatalogTemplateVersions"
+              for any project in the cluster. Default is false.
+            type: boolean
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          builtin:
+            description: Builtin if true specifies that this RoleTemplate was created
+              by Rancher and is immutable. Default to false.
+            type: boolean
+          clusterCreatorDefault:
+            description: ClusterCreatorDefault if true, a binding with this RoleTemplate
+              will be created for a users when they create a new cluster. ClusterCreatorDefault
+              is only evaluated if the context of the RoleTemplate is set to cluster.
+              Default to false.
+            type: boolean
+          context:
+            description: Context describes if the roleTemplate applies to clusters
+              or projects. Valid values are "project", "cluster" or "".
+            enum:
+            - project
+            - cluster
+            - ""
+            type: string
+          description:
+            description: Description holds text that describes the resource.
+            type: string
+          displayName:
+            description: DisplayName is the human-readable name displayed in the UI
+              for this resource.
+            type: string
+          external:
+            description: External if true specifies that rules for this RoleTemplate
+              should be gathered from a ClusterRole with the matching name. If set
+              to true the Rules on the template will not be evaluated. External's
+              value is only evaluated if the RoleTemplate's context is set to "cluster"
+              Default to false.
+            type: boolean
+          hidden:
+            description: Hidden if true informs the Rancher UI not to display this
+              RoleTemplate. Default to false.
+            type: boolean
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          locked:
+            description: Locked if true, new bindings will not be able to use this
+              RoleTemplate. Default to false.
+            type: boolean
+          metadata:
+            type: object
+          projectCreatorDefault:
+            description: ProjectCreatorDefault if true, a binding with this RoleTemplate
+              will be created for a user when they create a new project. ProjectCreatorDefault
+              is only evaluated if the context of the RoleTemplate is set to project.
+              Default to false.
+            type: boolean
+          roleTemplateNames:
+            description: RoleTemplateNames list of RoleTemplate names that this RoleTemplate
+              will inherit. This RoleTemplate will grant all rules defined in an inherited
+              RoleTemplate. Inherited RoleTemplates must already exist.
+            items:
+              type: string
+            type: array
+          rules:
+            description: Rules hold all the PolicyRules for this RoleTemplate.
+            items:
+              description: PolicyRule holds information that describes a policy rule,
+                but does not contain information about who the rule applies to or
+                which namespace the rule applies to.
+              properties:
+                apiGroups:
+                  description: APIGroups is the name of the APIGroup that contains
+                    the resources.  If multiple API groups are specified, any action
+                    requested against one of the enumerated resources in any API group
+                    will be allowed. "" represents the core API group and "*" represents
+                    all API groups.
+                  items:
+                    type: string
+                  type: array
+                nonResourceURLs:
+                  description: NonResourceURLs is a set of partial urls that a user
+                    should have access to.  *s are allowed, but only as the full,
+                    final step in the path Since non-resource URLs are not namespaced,
+                    this field is only applicable for ClusterRoles referenced from
+                    a ClusterRoleBinding. Rules can either apply to API resources
+                    (such as "pods" or "secrets") or non-resource URL paths (such
+                    as "/api"),  but not both.
+                  items:
+                    type: string
+                  type: array
+                resourceNames:
+                  description: ResourceNames is an optional white list of names that
+                    the rule applies to.  An empty set means that everything is allowed.
+                  items:
+                    type: string
+                  type: array
+                resources:
+                  description: Resources is a list of resources this rule applies
+                    to. '*' represents all resources.
+                  items:
+                    type: string
+                  type: array
+                verbs:
+                  description: Verbs is a list of Verbs that apply to ALL the ResourceKinds
+                    contained in this rule. '*' represents all verbs.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - verbs
+              type: object
+            type: array
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: RoleTemplate
+    listKind: RoleTemplateList
+    plural: roletemplates
+    singular: roletemplate
+  conditions:
+  - lastTransitionTime: "2023-10-11T02:04:11Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2023-10-11T02:04:11Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v3


### PR DESCRIPTION
The chart introduces the ability to define custom pcidevices roles for the rancher cluster.
This chart will be released into rancher/charts for installation on the rancher cluster.