### PR TITLE
Add harvester-node-manager-v0.1

### DIFF
--- a/charts/harvester-node-manager-v0-1/Chart.yaml
+++ b/charts/harvester-node-manager-v0-1/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: harvester-node-manager
+description: A Helm chart for Harvester Node Manager
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.0-dev
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.1.1"
+
+maintainers:
+  - name: harvester

--- a/charts/harvester-node-manager-v0-1/templates/NOTES.txt
+++ b/charts/harvester-node-manager-v0-1/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The harvester-node-manager has been installed into "{{ .Release.Namespace }}" namespace.

--- a/charts/harvester-node-manager-v0-1/templates/_helpers.tpl
+++ b/charts/harvester-node-manager-v0-1/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "harvester-node-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "harvester-node-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "harvester-node-manager.labels" -}}
+helm.sh/chart: {{ include "harvester-node-manager.chart" . }}
+{{ include "harvester-node-manager.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: node-manager
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "harvester-node-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "harvester-node-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/harvester-node-manager-v0-1/templates/crds/node.harvesterhci.io_ksmtuneds.yaml
+++ b/charts/harvester-node-manager-v0-1/templates/crds/node.harvesterhci.io_ksmtuneds.yaml
@@ -1,0 +1,157 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {}
+  creationTimestamp: null
+  name: ksmtuneds.node.harvesterhci.io
+spec:
+  group: node.harvesterhci.io
+  names:
+    kind: Ksmtuned
+    listKind: KsmtunedList
+    plural: ksmtuneds
+    shortNames:
+      - ksmtd
+    singular: ksmtuned
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.run
+          name: Run
+          type: string
+        - jsonPath: .spec.mode
+          name: Mode
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                ksmtunedParameters:
+                  properties:
+                    boost:
+                      type: integer
+                    decay:
+                      type: integer
+                    maxPages:
+                      type: integer
+                    minPages:
+                      type: integer
+                    sleepMsec:
+                      format: int64
+                      type: integer
+                  required:
+                    - boost
+                    - decay
+                    - maxPages
+                    - minPages
+                    - sleepMsec
+                  type: object
+                mergeAcrossNodes:
+                  maximum: 1
+                  type: integer
+                mode:
+                  default: standard
+                  description: KsmtunedMode defines the mode used by ksmtuned
+                  enum:
+                    - standard
+                    - high
+                    - customized
+                  type: string
+                run:
+                  default: stop
+                  enum:
+                    - stop
+                    - run
+                    - prune
+                  type: string
+                thresCoef:
+                  default: 20
+                  maximum: 100
+                  minimum: 0
+                  type: integer
+              required:
+                - ksmtunedParameters
+                - mergeAcrossNodes
+                - mode
+                - run
+                - thresCoef
+              type: object
+            status:
+              properties:
+                fullScans:
+                  description: how many times all mergeable areas have been scanned
+                  format: int64
+                  type: integer
+                ksmdPhase:
+                  default: Stopped
+                  description: ksmd status
+                  enum:
+                    - Stopped
+                    - Running
+                    - Pruned
+                  type: string
+                shared:
+                  description: how many shared pages are being used
+                  format: int64
+                  type: integer
+                sharing:
+                  description: how many more sites are sharing them i.e. how much saved
+                  format: int64
+                  type: integer
+                stableNodeChains:
+                  description: the number of KSM pages that hit the max_page_sharing
+                    limit
+                  format: int64
+                  type: integer
+                stableNodeDups:
+                  description: number of duplicated KSM pages
+                  format: int64
+                  type: integer
+                unshared:
+                  description: how many pages unique but repeatedly checked for merging
+                  format: int64
+                  type: integer
+                volatile:
+                  description: how many pages changing too fast to be placed in a tree
+                  format: int64
+                  type: integer
+              required:
+                - fullScans
+                - ksmdPhase
+                - shared
+                - sharing
+                - stableNodeChains
+                - stableNodeDups
+                - unshared
+                - volatile
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/harvester-node-manager-v0-1/templates/crds/node.harvesterhci.io_nodeconfigs.yaml
+++ b/charts/harvester-node-manager-v0-1/templates/crds/node.harvesterhci.io_nodeconfigs.yaml
@@ -1,0 +1,86 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {}
+  creationTimestamp: null
+  name: nodeconfigs.node.harvesterhci.io
+spec:
+  group: node.harvesterhci.io
+  names:
+    kind: NodeConfig
+    listKind: NodeConfigList
+    plural: nodeconfigs
+    shortNames:
+    - nconf
+    singular: nodeconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              ntpConfigs:
+                properties:
+                  ntpServers:
+                    type: string
+                required:
+                - ntpServers
+                type: object
+            type: object
+          status:
+            properties:
+              ntpConditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/harvester-node-manager-v0-1/templates/daemonset.yaml
+++ b/charts/harvester-node-manager-v0-1/templates/daemonset.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "harvester-node-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harvester-node-manager.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "harvester-node-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "harvester-node-manager.selectorLabels" . | nindent 8 }}
+        name: harvester-node-manager
+    spec:
+      serviceAccountName: {{ include "harvester-node-manager.name" . }}
+      containers:
+        - name: node-manager
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - harvester-node-manager
+          env:
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: HOST_PROC
+              value: /host/proc
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /sys/kernel/mm/ksm
+              name: ksm
+              readOnly: false
+            - mountPath: /host/proc
+              name: proc
+              readOnly: true
+            - mountPath: /var/run/dbus/system_bus_socket
+              name: dbus-socket
+              readOnly: true
+            - mountPath: /host/etc/systemd
+              name: host-systemd
+            - mountPath: /host/oem
+              name: host-oem
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: ksm
+          hostPath:
+            path: /sys/kernel/mm/ksm
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: dbus-socket
+          hostPath:
+            path: /var/run/dbus/system_bus_socket
+            type: ""
+        - name: host-systemd
+          hostPath:
+            path: /etc/systemd
+            type: ""
+        - name: host-oem
+          hostPath:
+            path: /oem
+            type: ""

--- a/charts/harvester-node-manager-v0-1/templates/rbac.yaml
+++ b/charts/harvester-node-manager-v0-1/templates/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "harvester-node-manager.labels" . | nindent 4 }}
+  name: {{ include "harvester-node-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "harvester-node-manager.name" . }}
+rules:
+  - apiGroups: [ "node.harvesterhci.io" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "watch", "list", "update" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "harvester-node-manager.labels" . | nindent 4 }}
+  name: {{ include "harvester-node-manager.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "harvester-node-manager.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "harvester-node-manager.name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/harvester-node-manager-v0-1/values.yaml
+++ b/charts/harvester-node-manager-v0-1/values.yaml
@@ -1,0 +1,24 @@
+# Default values for harvester-node-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: rancher/harvester-node-manager
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "master-head"
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+tolerations:
+  # this toleration is to have the daemonset runnable on master nodes
+  # remove it if your masters can't run pods
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  - effect: NoExecute
+    operator: Exists


### PR DESCRIPTION
The harvester-node-manager chart is tracking the latest branch, v0.2.x. harvester-node-manager v0.2.x is only used in Harvester 1.3 and beyond, so we need a way to publish updates to harvester-node-manager v0.1.x for use in maintaining releases prior to Harvester 1.3.

To create this directory, I copied over the state of the charts/harvester-node-manager directory prior to any of the commits that resulted due to harvester-node-manager v0.2.x branch:

	eaf3568 ("chart: update tolerations of node-manager")