### PR TITLE
updates to vm-import-controller

### DIFF
--- a/charts/harvester-vm-import-controller/templates/deployment.yaml
+++ b/charts/harvester-vm-import-controller/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "vm-import-controller.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "vm-import-controller.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
PR copies changes from https://github.com/harvester/vm-import-controller/pull/24 to ensure seamless upgrades of vm-import-controller when using PVC claims for temporary storage.