### PR TITLE
fix: add maxUnavailable for cloud provider upgrade

### DIFF
--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
   {{- include "harvester-cloud-provider.selectorLabels" . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Changing the value to 1 from the default 25% remedies the deployment update stuck problem in single-node clusters due to pod antiaffinity.

Related issue: harvester/harvester#5348