### PR TITLE
charts: bump harvester-csi-driver v0.1.18

### DIFF
--- a/charts/harvester-csi-driver/Chart.yaml
+++ b/charts/harvester-csi-driver/Chart.yaml
@@ -18,12 +18,12 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.1.6
+appVersion: v0.1.7
 
 maintainers:
   - name: harvester

--- a/charts/harvester-csi-driver/values.yaml
+++ b/charts/harvester-csi-driver/values.yaml
@@ -7,7 +7,7 @@ image:
     csiDriver:
       repository: rancher/harvester-csi-driver
       # Overrides the image tag whose default is the chart appVersion.
-      tag: "v0.1.5"
+      tag: "v0.1.7"
   csi:
     nodeDriverRegistrar:
       repository: rancher/mirrored-longhornio-csi-node-driver-registrar


### PR DESCRIPTION
    - release images for both x86/aarch64 platform