### PR TITLE
update rbac requirements for vm-import-controller

### DIFF
--- a/charts/harvester-vm-import-controller/templates/rbac.yaml
+++ b/charts/harvester-vm-import-controller/templates/rbac.yaml
@@ -34,6 +34,14 @@ rules:
   - persistentvolumeclaims
   verbs:
   - "*"
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
PR https://github.com/harvester/vm-import-controller/pull/31 allows end users to specify a custom storage class during the import process. 
To allow lookup of storage class the vm-import-controller now needs access to get and list storageclass objects in the cluster.

The PR adds the additional permissions needed for the same.