### PR TITLE
Release vm import v0.4.0

### DIFF
--- a/charts/harvester-vm-import-controller/Chart.yaml
+++ b/charts/harvester-vm-import-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.3.0
+appVersion: v0.4.0
 
 maintainers:
   - name: harvester

--- a/charts/harvester-vm-import-controller/templates/rbac.yaml
+++ b/charts/harvester-vm-import-controller/templates/rbac.yaml
@@ -34,6 +34,14 @@ rules:
   - persistentvolumeclaims
   verbs:
   - "*"
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
PR cherry picks commits from https://github.com/harvester/charts/pull/254

and updates vm-import-controller to release v0.4.0