### PR TITLE
Bump harvester-load-balancer to v0.4.0 for Harvester v1.4.0

### DIFF
--- a/charts/harvester-load-balancer/Chart.yaml
+++ b/charts/harvester-load-balancer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.3.0
+appVersion: v0.4.0
 
 home: https://github.com/harvester/harvester-load-balancer
 

--- a/charts/harvester-load-balancer/values.yaml
+++ b/charts/harvester-load-balancer/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: rancher/harvester-load-balancer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.3.0
+  tag: v0.4.0
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -46,7 +46,7 @@ webhook:
   image:
     repository: rancher/harvester-load-balancer-webhook
     pullPolicy: IfNotPresent
-    tag: v0.3.0
+    tag: v0.4.0
   httpsPort: 8443
   resources:
     limits:


### PR DESCRIPTION
Issue: https://github.com/harvester/harvester/issues/6158

Solution: Bump harvester-load-balancer to v0.4.0 for Harvester v1.4.0 


new image tag v0.4.0 are available.

https://hub.docker.com/layers/rancher/harvester-load-balancer-webhook/v0.4.0/images/sha256-1c22231f80fb9d8fe920c7d0746f0e9938d7e3a5857e7d549b09054cfcd32baf?context=explore

https://hub.docker.com/layers/rancher/harvester-load-balancer/v0.4.0/images/sha256-44435b896b9242820419a8083b3556ca9202a31a9888658f1ee598b8932fcbfd?context=explore