### PR TITLE
Bump harvester-load-balancer to v0.4.1 for Harvester v1.4.0

### DIFF
--- a/charts/harvester-load-balancer/Chart.yaml
+++ b/charts/harvester-load-balancer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.4.0
+appVersion: v0.4.1
 
 home: https://github.com/harvester/harvester-load-balancer
 

--- a/charts/harvester-load-balancer/values.yaml
+++ b/charts/harvester-load-balancer/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: rancher/harvester-load-balancer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.4.0
+  tag: v0.4.1
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -46,7 +46,7 @@ webhook:
   image:
     repository: rancher/harvester-load-balancer-webhook
     pullPolicy: IfNotPresent
-    tag: v0.4.0
+    tag: v0.4.1
   httpsPort: 8443
   resources:
     limits:


### PR DESCRIPTION
The LB refactor PR https://github.com/harvester/load-balancer-harvester/pull/31 has been merged; a new container image tag v0.4.1 was also released.

Bump LB chart version to v0.4.1.

Later, this chart version will be included in Harvester v1.4.0, following issues will be ready to verify on v1.4.0.

https://github.com/harvester/harvester/issues/5316
https://github.com/harvester/harvester/issues/4821
https://github.com/harvester/harvester/issues/4972
https://github.com/harvester/harvester/issues/5033