### PR TITLE
fix(harvester-cloud-provider): allow to disable kube-vip

### DIFF
--- a/charts/harvester-cloud-provider/Chart.yaml
+++ b/charts/harvester-cloud-provider/Chart.yaml
@@ -43,5 +43,6 @@ maintainers:
 
 dependencies:
   - name: kube-vip
+    condition: kube-vip.enabled
     version: 0.4.2
     repository: file://dependency_charts/kube-vip


### PR DESCRIPTION
Parameter  `kube-vip.enabled` is present in values, but it did nothing because the condition for the dependency was missing

Fixes https://github.com/harvester/harvester/issues/6527