### PR TITLE
include additional mounts to stage driver firmware

### DIFF
--- a/charts/nvidia-driver-runtime/templates/daemonset.yaml
+++ b/charts/nvidia-driver-runtime/templates/daemonset.yaml
@@ -46,6 +46,10 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: /sys
+            - name: firmware-search-path
+              mountPath: /sys/module/firmware_class/parameters/path
+            - name: nv-firmware
+              mountPath: /lib/firmware
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -66,3 +70,10 @@ spec:
           hostPath:
             path: /sys
             type: Directory
+        - name: firmware-search-path
+          hostPath:
+            path: /sys/module/firmware_class/parameters/path
+        - name: nv-firmware
+          hostPath:
+            path: /run/nvidia/driver/lib/firmware
+            type: DirectoryOrCreate


### PR DESCRIPTION
Related to: https://github.com/harvester/harvester/issues/6487

Looks like there has been a change in nvidia driver packaging which needs firmware files to be exposed to the underlying host.

https://github.com/NVIDIA/gpu-operator/commit/c4dce746b18dae1850cb2e6eadded6d28a76013d

The PR attempts to address the same.