### PR TITLE
charts: bump version to v0.1.1

### DIFF
--- a/charts/harvester-networkfs-manager/Chart.yaml
+++ b/charts/harvester-networkfs-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-networkfs-manager/values.yaml
+++ b/charts/harvester-networkfs-manager/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: rancher/harvester-networkfs-manager
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "main-head"
+  tag: "v0.1.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
    - for golang v1.22.7 and bci image 15.6

reference: https://github.com/harvester/harvester/issues/6568