### PR TITLE
rollback changes from pr-286 and mount /lib/firmware into daemonset

### DIFF
--- a/charts/nvidia-driver-runtime/templates/daemonset.yaml
+++ b/charts/nvidia-driver-runtime/templates/daemonset.yaml
@@ -46,9 +46,7 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: /sys
-            - name: firmware-search-path
-              mountPath: /sys/module/firmware_class/parameters/path
-            - name: nv-firmware
+            - name: lib-firmware
               mountPath: /lib/firmware
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -70,10 +68,7 @@ spec:
           hostPath:
             path: /sys
             type: Directory
-        - name: firmware-search-path
+        - name: lib-firmware
           hostPath:
-            path: /sys/module/firmware_class/parameters/path
-        - name: nv-firmware
-          hostPath:
-            path: /run/nvidia/driver/lib/firmware
-            type: DirectoryOrCreate
+            path: /lib/firmware
+            type: Directory


### PR DESCRIPTION
PR rolls back the original change in the nvidia driver-runtime chart to add additional firmware search paths.

PR also now mounts /lib/firmware directly into the daemonset as v1.4.x makes /lib/firmware an overlay fs.

Related to: https://github.com/harvester/harvester/issues/6487