### PR TITLE
Validate the network mapping configuration

### DIFF
--- a/charts/harvester-vm-import-controller/templates/rbac.yaml
+++ b/charts/harvester-vm-import-controller/templates/rbac.yaml
@@ -28,6 +28,13 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+    - "k8s.cni.cncf.io"
+  resources:
+    - "network-attachment-definitions"
+  verbs:
+    - "list"
+    - "watch"
+- apiGroups:
   - ""
   resources:
   - secrets


### PR DESCRIPTION
A new `apiGroups` is added to the `ClusterRole` to be able to list `network-attachment-definitions`.

Related to: https://github.com/harvester/harvester/issues/6491
