### PR TITLE
chore: bump vm-dhcp-controller to 0.3.3

### DIFF
--- a/charts/harvester-vm-dhcp-controller/Chart.yaml
+++ b/charts/harvester-vm-dhcp-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.2"
+appVersion: "v0.3.3"
 
 maintainers:
 - name: harvester


### PR DESCRIPTION
- chart version: 0.3.3
- app version: v0.3.3

Related issue: harvester/harvester#6942