### PR TITLE
harvester-cloud-provider: update kube-version and chart version

### DIFF
--- a/charts/harvester-cloud-provider/Chart.yaml
+++ b/charts/harvester-cloud-provider/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/harvester-cloud-provider/Chart.yaml
+++ b/charts/harvester-cloud-provider/Chart.yaml
@@ -28,7 +28,7 @@ appVersion: v0.2.4
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/namespace: kube-system
-  catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.29.0-0'
+  catalog.cattle.io/kube-version: '>= 1.23.0-0'
   catalog.cattle.io/release-name: harvester-cloud-provider
   catalog.cattle.io/os: linux
   catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.10.0-0'


### PR DESCRIPTION
We did not rely on the specific kube-version, so I remove the limitation of the kube-verson. To prevent some checking will be affected with this annotation. Also, update chart version to 0.2.8.