### PR TITLE
feat: add csi controller affinity rules

### DIFF
--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -110,13 +110,16 @@ spec:
                 values: ["true"]
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 90
+          - weight: 100
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
                 - key: app.kubernetes.io/name
                   operator: In
                   values: [{{ template "harvester-csi-driver.name" . }}]
+                - key: component
+                  operator: In
+                  values: [csi-controllers]
               topologyKey: kubernetes.io/hostname
       volumes:
         - hostPath:

--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -92,22 +92,14 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
+            # For RKE1
             - matchExpressions:
-              - key: node-role.harvesterhci.io/worker
-                operator: DoesNotExist
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
+              - key: node-role.kubernetes.io/controlplane
+                operator: Exists
+            # For RKE2
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
-                operator: In
-                values: ["true"]
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.harvesterhci.io/management
-                operator: In
-                values: ["true"]
+                operator: Exists
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -116,7 +108,7 @@ spec:
                 matchExpressions:
                 - key: app.kubernetes.io/name
                   operator: In
-                  values: [{{ template "harvester-csi-driver.name" . }}]
+                  values: [harvester-csi-driver]
                 - key: component
                   operator: In
                   values: [csi-controllers]

--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -88,6 +88,36 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.harvesterhci.io/worker
+                operator: DoesNotExist
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values: ["true"]
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.harvesterhci.io/management
+                operator: In
+                values: ["true"]
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 90
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values: [{{ template "harvester-csi-driver.name" . }}]
+              topologyKey: kubernetes.io/hostname
       volumes:
         - hostPath:
             path: {{ .Values.kubeletRootDir }}/harvester-plugins/driver.harvesterhci.io


### PR DESCRIPTION
This PR updates the CSI controller chart with new node affinity and pod anti-affinity rules to ensure that, within the guest cluster:

* The controller replicas _should_ be scheduled to run only on _distinct_ control plane nodes
* The controller replicas _must_ be scheduled to run on control plane nodes, not on worker nor etcd nodes

The first rule is a soft constraint. If there are more replicas than control plane nodes, the K8s scheduler can run multiple replicas on the same nodes. The second rule is a hard constraint i.e. the controller must only run on control plane nodes and never on worker nodes.

Note that I am not sure if we want to make these rules user-configurable.

Relevant issue: https://github.com/harvester/harvester/issues/7189

## Test Plan

Create a RKE2 guest cluster with 2 control plane nodes, 1 worker node and 1 etcd node:

```sh
kubectl get node  -owide
NAME                           STATUS   ROLES                       AGE   VERSION          INTERNAL-IP       EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
guest-rke2-pool1-55jj5-89lgw   Ready    control-plane,etcd,master   41m   v1.30.7+rke2r1   192.168.122.21    <none>        Ubuntu 22.04.5 LTS   5.15.0-1072-kvm   containerd://1.7.23-k3s2
guest-rke2-pool1-55jj5-v8dwv   Ready    control-plane,etcd,master   45m   v1.30.7+rke2r1   192.168.122.245   <none>        Ubuntu 22.04.5 LTS   5.15.0-1072-kvm   containerd://1.7.23-k3s2
guest-rke2-pool2-vx4fz-ddwhj   Ready    worker                      39m   v1.30.7+rke2r1   192.168.122.26    <none>        Ubuntu 22.04.5 LTS   5.15.0-1072-kvm   containerd://1.7.23-k3s2
guest-rke2-pool3-v6hnh-8gwh9   Ready    etcd                        42m   v1.30.7+rke2r1   192.168.122.42    <none>        Ubuntu 22.04.5 LTS   5.15.0-1072-kvm   containerd://1.7.23-k3s2
```

Initially, there 3 controller replicas are scheduled non-deterministically:

```sh
$ kubectl --kubeconfig ~/Downloads/guest-rke2.yaml -n kube-system get po -lcomponent=csi-controllers -owide
NAME                                               READY   STATUS    RESTARTS   AGE   IP             NODE                           NOMINATED NODE   READINESS GATES
harvester-csi-driver-controllers-98d6566d9-2d22n   3/3     Running   0          23m   10.42.150.66   guest-rke2-pool1-55jj5-v8dwv   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-2xjjw   3/3     Running   0          23m   10.42.150.72   guest-rke2-pool1-55jj5-v8dwv   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-z5bjp   3/3     Running   0          23m   10.42.150.65   guest-rke2-pool1-55jj5-v8dwv   <none>           <none>
```

Update the CSI controller `Deployment` spec with the node affinity and pod anti-affinity rules using:

```sh
kubectl -n kube-system edit deploy/harvester-csi-driver-controllers
```

Scale the CSI controller to 10 replicas:

```sh
kubectl -n kube-system scale deploy/harvester-csi-driver-controllers --replicas=10
```

Confirm that all the replicas:

* are scheduled to run only on control plane nodes, not worker nor etcd nodes
* are distributed across the control plane nodes, instead of just one node
* are healthy

```sh
kubectl -n kube-system get po -lcomponent=csi-controllers -owide
NAME                                               READY   STATUS    RESTARTS   AGE   IP              NODE                           NOMINATED NODE   READINESS GATES
harvester-csi-driver-controllers-98d6566d9-26xjk   3/3     Running   0          22s   10.42.209.200   guest-rke2-pool1-55jj5-89lgw   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-2d22n   3/3     Running   0          24m   10.42.150.66    guest-rke2-pool1-55jj5-v8dwv   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-2xjjw   3/3     Running   0          24m   10.42.150.72    guest-rke2-pool1-55jj5-v8dwv   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-7wgms   3/3     Running   0          22s   10.42.194.205   guest-rke2-pool2-vx4fz-ddwhj   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-f6k5p   3/3     Running   0          22s   10.42.150.4     guest-rke2-pool3-v6hnh-8gwh9   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-fmjmg   3/3     Running   0          22s   10.42.209.198   guest-rke2-pool1-55jj5-89lgw   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-mr4q8   3/3     Running   0          22s   10.42.150.5     guest-rke2-pool3-v6hnh-8gwh9   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-tsk8k   3/3     Running   0          23s   10.42.194.204   guest-rke2-pool2-vx4fz-ddwhj   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-v4hlj   3/3     Running   0          22s   10.42.209.199   guest-rke2-pool1-55jj5-89lgw   <none>           <none>
harvester-csi-driver-controllers-98d6566d9-z5bjp   3/3     Running   0          24m   10.42.150.65    guest-rke2-pool1-55jj5-v8dwv   <none>           <none>
```