### PR TITLE
chore: remove unneeded python3 dependency from GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,6 @@ jobs:
         with:
           version: v3.4.0
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
 


### PR DESCRIPTION
This PR removes the unneeded python3 dependency from GHA. As of yesterday, [CI started failing](https://github.com/harvester/charts/actions/runs/12738947411/job/35503198243#step:5:6) due to missing python 3.7 library. The `ubuntu:latest` has been bumped to [ubuntu 24.04.5](https://github.com/harvester/charts/actions/runs/12738947411/job/35503198243#step:1:4). It was still at [ubuntu 22.04.5](https://github.com/harvester/charts/actions/runs/12684586127/job/35353514223#step:1:4) about 4 days ago.

Both the `lint-test` and `release` jobs passed in my [`release` fork](https://github.com/ihcsim/harvester-charts/actions/runs/12753416927/job/35545049441), without requiring python 3.