### PR TITLE
chore: bump vm-dhcp-controller to 1.5.0-dev.1

### DIFF
--- a/charts/harvester-vm-dhcp-controller/Chart.yaml
+++ b/charts/harvester-vm-dhcp-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 1.5.0-dev.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.3"
+appVersion: "v1.5.0-dev.1"
 
 maintainers:
 - name: harvester


### PR DESCRIPTION
- Chart version: 1.5.0-dev.1
- App version: v1.5.0-dev.1