### PR TITLE
chore: bump harvester-load-balancer to 1.5.0-dev.0

### DIFF
--- a/charts/harvester-load-balancer/Chart.yaml
+++ b/charts/harvester-load-balancer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 1.5.0-dev.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.4.0
+appVersion: v1.5.0-dev.0
 
 home: https://github.com/harvester/harvester-load-balancer
 

--- a/charts/harvester-load-balancer/values.yaml
+++ b/charts/harvester-load-balancer/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: rancher/harvester-load-balancer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.4.0
+  tag: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -46,7 +46,7 @@ webhook:
   image:
     repository: rancher/harvester-load-balancer-webhook
     pullPolicy: IfNotPresent
-    tag: v0.4.0
+    tag: ""
   httpsPort: 8443
   resources:
     limits:


### PR DESCRIPTION
For harvester v1.5.x release

latest image: https://github.com/harvester/load-balancer-harvester/releases/tag/v1.5.0-dev.0


refer: https://github.com/harvester/harvester/wiki/Branch-Strategy#versioning