### PR TITLE
fix: grant nad update permission to vm-dhcp-controller

### DIFF
--- a/charts/harvester-vm-dhcp-controller/templates/rbac.yaml
+++ b/charts/harvester-vm-dhcp-controller/templates/rbac.yaml
@@ -11,7 +11,7 @@ rules:
   verbs: [ "*" ]
 - apiGroups: [ "k8s.cni.cncf.io" ]
   resources: [ "network-attachment-definitions" ]
-  verbs: [ "get", "watch", "list" ]
+  verbs: [ "get", "watch", "list", "update" ]
 - apiGroups: [ "" ]
   resources: [ "nodes" ]
   verbs: [ "get", "watch", "list" ]


### PR DESCRIPTION
Decoupling IPPools and NADs means the relationship between the two parties will be built upon labels. The controller needs to update the referenced NADs with appropriate labels, hence the UPDATE permission should be granted to the controller's service account.

Related issue: harvester/harvester#6240