### PR TITLE
charts: bump node-disk-manager v1.5.0-dev.2

### DIFF
--- a/charts/harvester-node-disk-manager/Chart.yaml
+++ b/charts/harvester-node-disk-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0-dev.1
+version: 1.5.0-dev.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.5.0-dev.1"
+appVersion: "v1.5.0-dev.2"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-node-disk-manager/values.yaml
+++ b/charts/harvester-node-disk-manager/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: rancher/harvester-node-disk-manager
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.5.0-dev.1"
+  tag: "v1.5.0-dev.2"
 
 webhook:
   replicas: 1
@@ -14,7 +14,7 @@ webhook:
     repository: rancher/harvester-node-disk-manager-webhook
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v1.5.0-dev.1"
+    tag: "v1.5.0-dev.2"
   httpsPort: 8443
 
 imagePullSecrets: []


### PR DESCRIPTION
```
bump node-disk-manager v1.5.0-dev.2
```

Release here: https://github.com/harvester/node-disk-manager/releases/tag/v1.5.0-dev.2