### PR TITLE
charts: correct the serviceAccountName to remove validator

### DIFF
--- a/charts/harvester-csi-driver-lvm/templates/uninstall-hook.yaml
+++ b/charts/harvester-csi-driver-lvm/templates/uninstall-hook.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       name: delete-harvester-csi-driver-lvm-webhook
     spec:
-      serviceAccountName: harvester
+      serviceAccountName: harvester-csi-driver-lvm-webhook
       restartPolicy: Never
       containers:
       - name: delete-lvm-validator-webhook


### PR DESCRIPTION
    - we should use the lvm webhook service account