### PR TITLE
Update to seeder helm chart to support mutating webhook

### DIFF
--- a/charts/harvester-seeder/templates/rbac.yaml
+++ b/charts/harvester-seeder/templates/rbac.yaml
@@ -88,6 +88,7 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
   verbs:
   - get
   - watch


### PR DESCRIPTION
changes to seeder chart to provide permissions to setup and maange the new mutatingwebhook implementation for cluster resoruces

Related issue: https://github.com/harvester/harvester/issues/7949