### PR TITLE
chore: change nvidia driver image pull policy to IfNotPresent

### DIFF
--- a/charts/nvidia-driver-runtime/Chart.yaml
+++ b/charts/nvidia-driver-runtime/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0-dev.0
+version: 1.5.0-dev.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.5.0-dev.0
+appVersion: v1.5.0-dev.1
 
 maintainers:
   - name: harvester

--- a/charts/nvidia-driver-runtime/values.yaml
+++ b/charts/nvidia-driver-runtime/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: rancher/harvester-nvidia-driver-toolkit
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: sle-micro-head
 


### PR DESCRIPTION
This PR changed the nvidia-driver-runtime's image pull policy setting to `IfNotPresent` to reduce deployment friction in air-gapped environment.

Issue: https://github.com/harvester/harvester/issues/8000