### PR TITLE
chore: change nvidia-driver-toolset pull policy to IfNotPresent (#353)

### DIFF
--- a/charts/nvidia-driver-runtime/values.yaml
+++ b/charts/nvidia-driver-runtime/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: rancher/harvester-nvidia-driver-toolkit
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: sle-micro-head
 


### PR DESCRIPTION
This PR backports #353 to `master`. The versions in `charts/nvidia-driver-runtime/Chart.yaml` weren't bumped in previous commits. Let me know if they need to be.