### PR TITLE
charts: add pullPolicy and bump kubectl image

### DIFF
--- a/charts/harvester-csi-driver-lvm/templates/uninstall-hook.yaml
+++ b/charts/harvester-csi-driver-lvm/templates/uninstall-hook.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
       - name: delete-lvm-validator-webhook
         image: {{ .Values.hookImage.repository }}:{{ .Values.hookImage.tag }}
+        imagePullPolicy: {{ .Values.hookImage.pullPolicy }}
         args:
           - delete
           - validatingwebhookconfiguration

--- a/charts/harvester-csi-driver-lvm/values.yaml
+++ b/charts/harvester-csi-driver-lvm/values.yaml
@@ -18,7 +18,7 @@ hookImage:
   repository: rancher/kubectl
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.29.2"
+  tag: "v1.32.3"
 
 nameOverride: ""
 


### PR DESCRIPTION


<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The old kubectl image is too old.
Also, we would like to define the image pullPolicy with a dynamic definition.

#### Solution:
    - bump kubectl image v1.32.3
    - add pullPolicy for uninstall-hook

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
