### PR TITLE
charts: bump node-disk-manager 0.7.9

### DIFF
--- a/charts/harvester-node-disk-manager/Chart.yaml
+++ b/charts/harvester-node-disk-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.8
+version: 0.7.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.10"
+appVersion: "v0.7.11"
 
 maintainers:
   - name: harvester


### PR DESCRIPTION
    - For the latest image version v0.7.11

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
We need the latest NDM image to resolve the duplicated device path issue. 

#### Solution:
Bump chart 0.7.9 with the latest image v0.7.11

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
