### PR TITLE
chore: bump charts jumping to 1.5.1 with dev versions

### DIFF
--- a/charts/harvester-load-balancer/Chart.yaml
+++ b/charts/harvester-load-balancer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1-dev.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v1.5.0"
+appVersion: "v1.5.1-dev.1"
 
 home: https://github.com/harvester/harvester-load-balancer
 

--- a/charts/harvester-network-controller/Chart.yaml
+++ b/charts/harvester-network-controller/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v1.5.0"
+appVersion: "v1.5.1-dev.0"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-networkfs-manager/Chart.yaml
+++ b/charts/harvester-networkfs-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.5.0"
+appVersion: "v1.5.1-dev.0"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-node-disk-manager/Chart.yaml
+++ b/charts/harvester-node-disk-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.5.0"
+appVersion: "v1.5.1-dev.0"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-node-disk-manager/values.yaml
+++ b/charts/harvester-node-disk-manager/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: rancher/harvester-node-disk-manager
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.5.0"
+  tag: "v1.5.1-dev.0"
 
 webhook:
   replicas: 1
@@ -14,7 +14,7 @@ webhook:
     repository: rancher/harvester-node-disk-manager-webhook
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v1.5.0"
+    tag: "v1.5.1-dev.0"
   httpsPort: 8443
 
 imagePullSecrets: []

--- a/charts/harvester-node-manager/Chart.yaml
+++ b/charts/harvester-node-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.5.0"
+appVersion: "v1.5.1-dev.0"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-seeder/Chart.yaml
+++ b/charts/harvester-seeder/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.5.0"
+appVersion: "v1.5.1-dev.0"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-vm-import-controller/Chart.yaml
+++ b/charts/harvester-vm-import-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.5.0"
+appVersion: "v1.5.1-dev.0"
 
 maintainers:
   - name: harvester


### PR DESCRIPTION
Bump all the default shipped charts and app versions for preparing the v1.5.1-rc1 release. pcidevices and nvidia-driver-runtime charts were handled in #367. This PR takes care the rest.

Note: All the charts were on 1.5.0, and we need first to bump them to 1.5.0-dev.0 so that we can leverage the CI task to automate the RC1 bump. This is typically done by each component owner, as they are the ones who work on the features and fixes, and know when it's ready to release a new version of the component.