### PR TITLE
minor change to kubeovn operator to drop version argument

### DIFF
--- a/charts/kubeovn-operator/templates/deployment.yaml
+++ b/charts/kubeovn-operator/templates/deployment.yaml
@@ -26,7 +26,6 @@ spec:
         - --health-probe-bind-address=:8081
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         - --namespace={{ .Release.Namespace }}
-        - --version={{ .Chart.AppVersion }}
         command:
         - /manager
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Currently kubeovn-operator chart uses `version` for kubeovn images based on value of `Chart.Appversion`

This causes issues as rc* tags are not valid kubovn image tags.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR drops the version argument, which results in operator defaulting to the default version in operator package.
https://github.com/harvester/kubeovn-operator/pull/7

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/7413
#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
