### PR TITLE
Add new roles to node-disk-manager-webhook

### DIFF
--- a/charts/harvester-node-disk-manager/templates/rbac.yaml
+++ b/charts/harvester-node-disk-manager/templates/rbac.yaml
@@ -71,6 +71,9 @@ rules:
   - apiGroups: [ "admissionregistration.k8s.io" ]
     resources: [ "validatingwebhookconfigurations", "mutatingwebhookconfigurations" ]
     verbs: [ "*" ]
+  - apiGroups: ["longhorn.io"]
+    resources: ["volumes", "nodes", "backingimages", "replicas"] 
+    verbs: [ "get", "watch", "list" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adding new roles for:
* longhorn.io - volumes/nodes/backingimages

This is because incoming validation changes for the blockdevices introduce new caches which require those privileges

#### Problem:
In order to validate the statuses of backing images and volumes related with blockdevices we had to introduce caches in PR: https://github.com/harvester/node-disk-manager/pull/244 where those permissions are required

#### Solution:
Add the permissions to the node-disk-manager-webhook's cluster role

#### Related Issue(s):
https://github.com/harvester/harvester/issues/3344

#### Test plan:
In PR: https://github.com/harvester/node-disk-manager/pull/248

#### Additional documentation or context
N/A