### PR TITLE
Up network-controller deployment and daemonset  memory limits to 256Mi

### DIFF
--- a/charts/harvester-network-controller/values.yaml
+++ b/charts/harvester-network-controller/values.yaml
@@ -15,7 +15,7 @@ vipEnabled: false
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 10m
     memory: 64Mi


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

OOM is frequently observed on network-controller daemonset and deployment

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Up the memory limits.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/9469

#### Test plan:
<!-- Describe the test plan by steps. -->

Monitor the network related PODs when cluster starts up, there should be as few OOM as possible.

#### Additional documentation or context
