### PR TITLE
Add support for secrets and host path similar to harvester-csi-driver

### DIFF
--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -36,8 +36,13 @@ spec:
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - mountPath: /etc/kubernetes/cloud-config
-              name: cloud-config
+            - name: cloud-config
+              readOnly: true
+              {{- if or .Values.cloudConfig.secretName .Values.cloudConfig.hostPath }}
+              mountPath: /etc/kubernetes/
+              {{- else }}
+              mountPath: /etc/kubernetes/cloud-config
+              {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -52,6 +57,15 @@ spec:
       {{- end }}
       volumes:
         - name: cloud-config
+        {{- if .Values.cloudConfig.secretName }}
+          secret:
+            secretName: {{ .Values.cloudConfig.secretName }}
+        {{- else if .Values.cloudConfig.hostPath }}
           hostPath:
-            path: {{ required "A valid cloudConfigPath is required!" .Values.cloudConfigPath }}
+            path: {{ .Values.cloudConfig.hostPath }}
             type: File
+        {{- else }}
+          hostPath:
+            path: {{ required "A valid cloudConfigPath, cloudConfig.secretName or cloudConfig.hostPath is required!" .Values.cloudConfigPath }}
+            type: DirectoryOrCreate
+        {{- end }}

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -11,6 +11,9 @@ image:
   tag: "master-head"
 
 cloudConfigPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
+cloudConfig:
+  secretName: ""
+  hostPath: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
#### Problem:
I'd like to be able to use a cloud config from a secret.

#### Solution:
Add configuration options for volumes and volume mounts for the deployment.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #9503 https://github.com/harvester/harvester/issues/9503

#### Test plan:
run 
- `helm template test . --namespace kube-system`
- `helm template test . --namespace kube-system --set 'cloudConfig.hostPath=/var/lib/test'`
- `helm template test . --namespace kube-system --set 'cloudConfig.secretName=harvester-cloud-config'`

ensure output is as expected

#### Additional documentation or context
