### PR TITLE
[release-v17] Up network-controller deployment and daemonset  memory limits to 256Mi

### DIFF
--- a/charts/harvester-network-controller/values.yaml
+++ b/charts/harvester-network-controller/values.yaml
@@ -15,7 +15,7 @@ vipEnabled: false
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 10m
     memory: 64Mi


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

PR https://github.com/harvester/charts/pull/434 to release-v1.7 branch

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

cherry-pick commits from PR https://github.com/harvester/charts/pull/434

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/9469

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
