### PR TITLE
Bump kubeovn charts to v1.15.0

### DIFF
--- a/charts/kubeovn-operator-crd/Chart.yaml
+++ b/charts/kubeovn-operator-crd/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.0-dev.0
+version: 1.15.0-dev.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.15.0-dev.0
+appVersion: v1.15.0-dev.1
 
 maintainers:
 - name: harvester

--- a/charts/kubeovn-operator-crd/templates/crd.yaml
+++ b/charts/kubeovn-operator-crd/templates/crd.yaml
@@ -59,6 +59,9 @@ spec:
                     type: string
                   mountLocalBinDir:
                     type: boolean
+                  nonPrimaryCNI:
+                    default: true
+                    type: boolean
                 type: object
               components:
                 default: {}
@@ -131,6 +134,15 @@ spec:
                   u2oInterconnection:
                     default: false
                     type: boolean
+                  enableDNSNameResolver:
+                    default: false
+                    type: boolean
+                  enableOVNLBPreferLocal:
+                    default: false
+                    type: boolean
+                  npEnforcement:
+                    default: standard
+                    type: string
                 type: object
               debug:
                 default: {}
@@ -202,14 +214,8 @@ spec:
                           repository:
                             default: kube-ovn
                             type: string
-                          supportArm:
-                            default: true
-                            type: boolean
                           tag:
                             type: string
-                          thirdParty:
-                            default: true
-                            type: boolean
                           vpcRepository:
                             default: vpc-nat-gateway
                             type: string
@@ -600,6 +606,9 @@ spec:
                         default: ovn-vlan
                         type: string
                     type: object
+                  skipConnTrackDstCIDRs:
+                    default: ""
+                    type: string
                 type: object
               openVSwitchDir:
                 default: /etc/origin/openvswitch

--- a/charts/kubeovn-operator/Chart.yaml
+++ b/charts/kubeovn-operator/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.0-dev.0
+version: 1.15.0-dev.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.15.0-dev.0
+appVersion: v1.15.0-dev.1
 
 maintainers:
 - name: harvester

--- a/charts/kubeovn-operator/templates/configmap.yaml
+++ b/charts/kubeovn-operator/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
       cniConfigDir: /etc/cni/net.d
       cniConfigPriority: "90"
       localBinDir: /usr/local/bin
+      nonPrimaryCNI: {{ .Values.configurationSpec.cniConf.nonPrimaryCNI | default true }}
     components:
       OVSDBConTimeout: {{ .Values.configurationSpec.components.OVSDBConTimeout | default 3 }}
       OVSDBInactivityTimeout: {{ .Values.configurationSpec.components.OVSDBInactivityTimeout | default 10 }}
@@ -35,6 +36,9 @@ data:
       secureServing: {{ .Values.configurationSpec.components.secureServing | default false }}
       setVLANTxOff:  {{ .Values.configurationSpec.components.setVLANTxOff | default false }}
       u2oInterconnection:  {{ .Values.configurationSpec.components.u2oInterconnection | default false }}
+      enableDNSNameResolver: {{ .Values.configurationSpec.components.enableDNSNameResolver | default false }}
+      enableOVNLBPreferLocal: {{ .Values.configurationSpec.components.enableOVNLBPreferLocal | default false }}
+      npEnforcement: {{ .Values.configurationSpec.components.npEnforcement | default "standard" }}
     debug:
       mirrorInterface: {{.Values.configurationSpec.debug.mirrorInterface | default "mirror0"}}
     dpdkCPU:  {{.Values.configurationSpec.dpdkCPU | default "0" | quote}}
@@ -52,8 +56,6 @@ data:
         kubeovn:
           dpdkRepository: {{ .Values.configurationSpec.global.images.kubeovn.dpdkRepository | default "kube-ovn-dpdk" }}
           repository: {{ .Values.configurationSpec.global.images.kubeovn.repository | default "kube-ovn" }}
-          supportArm: {{ .Values.configurationSpec.global.images.kubeovn.supportArm | default "true" }}
-          thirdParty:  {{ .Values.configurationSpec.global.images.kubeovn.thirdParty | default "true" }}
           vpcRepository: {{ .Values.configurationSpec.global.images.kubeovn.vpcRepository | default "vpc-nat-gateway" }}
       registry:
         address: {{ .Values.configurationSpec.global.registry.address | default "docker.io/kubeovn" }}
@@ -122,6 +124,7 @@ data:
       ovnNorthdProbeInterval: {{ .Values.configurationSpec.networking.ovnNorthdProbeInterval | default "5000" }}
       ovnRemoteOpenflowInterval: {{ .Values.configurationSpec.networking.ovnRemoteOpenflowInterval | default "10" }}
       ovnRemoteProbeInterval: {{ .Values.configurationSpec.networking.ovnRemoteProbeInterval | default "10000" }}
+      skipConnTrackDstCIDRs: {{ .Values.configurationSpec.networking.skipConnTrackDstCIDRs | default "" }}
       podNicType: veth-pair
       probeInterval:  {{ .Values.configurationSpec.networking.probeInterval | default "180000" }}
       tunnelType: vxlan

--- a/charts/kubeovn-operator/templates/configuration.yaml
+++ b/charts/kubeovn-operator/templates/configuration.yaml
@@ -16,6 +16,7 @@ spec:
     cniConfigDir: /etc/cni/net.d
     cniConfigPriority: "90"
     localBinDir: /usr/local/bin
+    nonPrimaryCNI: {{ .Values.configurationSpec.cniConf.nonPrimaryCNI | default true }}
   components:
     OVSDBConTimeout: {{ .Values.configurationSpec.components.OVSDBConTimeout | default 3 }}
     OVSDBInactivityTimeout: {{ .Values.configurationSpec.components.OVSDBInactivityTimeout | default 10 }}
@@ -39,6 +40,9 @@ spec:
     secureServing: {{ .Values.configurationSpec.components.secureServing | default false }}
     setVLANTxOff:  {{ .Values.configurationSpec.components.setVLANTxOff | default false }}
     u2oInterconnection:  {{ .Values.configurationSpec.components.u2oInterconnection | default false }}
+    enableDNSNameResolver: {{ .Values.configurationSpec.components.enableDNSNameResolver | default false }}
+    enableOVNLBPreferLocal: {{ .Values.configurationSpec.components.enableOVNLBPreferLocal | default false }}
+    npEnforcement: {{ .Values.configurationSpec.components.npEnforcement | default "standard" }}
   debug:
     mirrorInterface: {{.Values.configurationSpec.debug.mirrorInterface | default "mirror0"}}
   dpdkCPU:  {{.Values.configurationSpec.dpdkCPU | default "0" | quote}}
@@ -56,8 +60,6 @@ spec:
       kubeovn:
         dpdkRepository: {{ .Values.configurationSpec.global.images.kubeovn.dpdkRepository | default "kube-ovn-dpdk" }}
         repository: {{ .Values.configurationSpec.global.images.kubeovn.repository | default "kube-ovn" }}
-        supportArm: {{ .Values.configurationSpec.global.images.kubeovn.supportArm | default "true" }}
-        thirdParty:  {{ .Values.configurationSpec.global.images.kubeovn.thirdParty | default "true" }}
         vpcRepository: {{ .Values.configurationSpec.global.images.kubeovn.vpcRepository | default "vpc-nat-gateway" }}
     registry:
       address: {{ .Values.configurationSpec.global.registry.address | default "docker.io/kubeovn" }}
@@ -126,6 +128,7 @@ spec:
     ovnNorthdProbeInterval: {{ .Values.configurationSpec.networking.ovnNorthdProbeInterval | default "5000" }} 
     ovnRemoteOpenflowInterval: {{ .Values.configurationSpec.networking.ovnRemoteOpenflowInterval | default "10" }} 
     ovnRemoteProbeInterval: {{ .Values.configurationSpec.networking.ovnRemoteProbeInterval | default "10000" }} 
+    skipConnTrackDstCIDRs: {{ .Values.configurationSpec.networking.skipConnTrackDstCIDRs | default "" }}
     podNicType: veth-pair
     probeInterval:  {{ .Values.configurationSpec.networking.probeInterval | default "180000" }} 
     tunnelType: vxlan

--- a/charts/kubeovn-operator/values.yaml
+++ b/charts/kubeovn-operator/values.yaml
@@ -59,6 +59,8 @@ tolerations: []
 affinity: {}
 enableConfiguration: false
 configurationSpec:
+  cniConf:
+    nonPrimaryCNI: true
   components:
     OVSDBConTimeout: 3
     OVSDBInactivityTimeout: 10
@@ -82,6 +84,9 @@ configurationSpec:
     secureServing: false
     setVLANTxOff: false
     u2oInterconnection: false
+    enableDNSNameResolver: false
+    enableOVNLBPreferLocal: false
+    npEnforcement: standard
   debug:
     mirrorInterface: mirror0
   dpdkCPU: "0"
@@ -92,8 +97,6 @@ configurationSpec:
       kubeovn:
         dpdkRepository: kube-ovn-dpdk
         repository: kube-ovn
-        supportArm: true
-        thirdParty: true
         vpcRepository: vpc-nat-gateway
     registry:
       address: docker.io/kubeovn
@@ -151,6 +154,7 @@ configurationSpec:
     ovnRemoteProbeInterval: 10000
     probeInterval: 180000
     nodeLocalDNSIPS: ""
+    skipConnTrackDstCIDRs: ""
   vlan:
     providerName: {}
     vlanId: {}


### PR DESCRIPTION

#### Problem:
bump kubeovn-operator to v1.15.0

#### Solution:
bump kubeovn-operator to v1.15.0

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9828

#### Test plan:


#### Additional documentation or context
