### PR TITLE
Add Scrutiny Helm chart

### DIFF
--- a/charts/scrutiny/Chart.yaml
+++ b/charts/scrutiny/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: scrutiny
+description: A Helm chart for Scrutiny (web, collector and InfluxDB)
+home: https://github.com/analogj/scrutiny
+type: application
+version: 0.1.0
+appVersion: "master"
+maintainers:
+  - name: harvester

--- a/charts/scrutiny/templates/_helpers.tpl
+++ b/charts/scrutiny/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{- define "scrutiny.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "scrutiny.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "scrutiny.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "scrutiny.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "scrutiny.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "scrutiny.labels" -}}
+helm.sh/chart: {{ include "scrutiny.chart" . }}
+{{ include "scrutiny.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/scrutiny/templates/daemonset-collector.yaml
+++ b/charts/scrutiny/templates/daemonset-collector.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "scrutiny.fullname" . }}-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scrutiny.labels" . | nindent 4 }}
+    app.kubernetes.io/component: collector
+spec:
+  selector:
+    matchLabels:
+      {{- include "scrutiny.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: collector
+  template:
+    metadata:
+      labels:
+        {{- include "scrutiny.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: collector
+    spec:
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      containers:
+        - name: collector
+          image: {{ .Values.collector.image }}
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - "SYS_RAWIO"
+          env:
+            - name: COLLECTOR_API_ENDPOINT
+              value: "http://{{ include `scrutiny.fullname` . }}-web:{{ .Values.web.service.port }}"
+            - name: COLLECTOR_RUN_STARTUP
+              value: "{{ .Values.collector.runStartup }}"
+            - name: COLLECTOR_RUN_STARTUP_SLEEP
+              value: "{{ .Values.collector.runStartupSleep }}"
+            - name: COLLECTOR_CRON_SCHEDULE
+              value: "{{ .Values.collector.cronSchedule }}"
+            - name: COLLECTOR_HOST_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: udev
+              mountPath: /run/udev
+              readOnly: true
+            - name: dev
+              mountPath: /dev
+              readOnly: true
+      volumes:
+        - name: udev
+          hostPath:
+            path: /run/udev
+        - name: dev
+          hostPath:
+            path: /dev

--- a/charts/scrutiny/templates/deployment-influxdb.yaml
+++ b/charts/scrutiny/templates/deployment-influxdb.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "scrutiny.fullname" . }}-influxdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scrutiny.labels" . | nindent 4 }}
+    app.kubernetes.io/component: influxdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "scrutiny.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: influxdb
+  template:
+    metadata:
+      labels:
+        {{- include "scrutiny.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: influxdb
+    spec:
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      containers:
+        - name: influxdb
+          image: {{ .Values.influxdb.image }}
+          ports:
+            - containerPort: {{ .Values.influxdb.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.influxdb.service.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: influxdb-data
+              mountPath: /var/lib/influxdb2
+      volumes:
+        - name: influxdb-data
+          persistentVolumeClaim:
+            claimName: {{ include "scrutiny.fullname" . }}-influxdb-pvc

--- a/charts/scrutiny/templates/deployment-web.yaml
+++ b/charts/scrutiny/templates/deployment-web.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "scrutiny.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scrutiny.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "scrutiny.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "scrutiny.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      containers:
+        - name: web
+          image: {{ .Values.web.image }}
+          ports:
+            - containerPort: {{ .Values.web.service.port }}
+          env:
+            - name: SCRUTINY_WEB_INFLUXDB_HOST
+              value: {{ include "scrutiny.fullname" . }}-influxdb
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: {{ .Values.web.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: {{ .Values.web.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /opt/scrutiny/config
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: {{ include "scrutiny.fullname" . }}-config-pvc

--- a/charts/scrutiny/templates/pvc-config.yaml
+++ b/charts/scrutiny/templates/pvc-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "scrutiny.fullname" . }}-config-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scrutiny.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.web.persistence.size }}

--- a/charts/scrutiny/templates/pvc-influxdb.yaml
+++ b/charts/scrutiny/templates/pvc-influxdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "scrutiny.fullname" . }}-influxdb-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scrutiny.labels" . | nindent 4 }}
+    app.kubernetes.io/component: influxdb
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.influxdb.persistence.size }}

--- a/charts/scrutiny/templates/service-influxdb.yaml
+++ b/charts/scrutiny/templates/service-influxdb.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scrutiny.fullname" . }}-influxdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scrutiny.labels" . | nindent 4 }}
+    app.kubernetes.io/component: influxdb
+spec:
+  clusterIP: None
+  selector:
+    {{- include "scrutiny.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: influxdb
+  ports:
+    - port: {{ .Values.influxdb.service.port }}
+      targetPort: {{ .Values.influxdb.service.port }}

--- a/charts/scrutiny/templates/service-web.yaml
+++ b/charts/scrutiny/templates/service-web.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scrutiny.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scrutiny.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  selector:
+    {{- include "scrutiny.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  ports:
+    - protocol: TCP
+      port: {{ .Values.web.service.port }}
+      targetPort: {{ .Values.web.service.port }}

--- a/charts/scrutiny/values.yaml
+++ b/charts/scrutiny/values.yaml
@@ -1,0 +1,30 @@
+nameOverride: ""
+fullnameOverride: ""
+
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  - effect: NoExecute
+    operator: Exists
+
+influxdb:
+  image: influxdb:2.8
+  service:
+    port: 8086
+  persistence:
+    size: 10Gi
+
+web:
+  image: ghcr.io/analogj/scrutiny:master-web
+  service:
+    port: 8080
+  persistence:
+    size: 10Mi
+
+collector:
+  image: ghcr.io/analogj/scrutiny:master-collector
+  runStartup: true
+  # Delay the first collection by 45 seconds to allow the WebUI and InfluxDB services to start up.
+  runStartupSleep: 45
+  # Collect metrics every hour.
+  cronSchedule: "0 * * * *"


### PR DESCRIPTION
#### Problem:
Prometheus node-exporter does not collect SMART values of the disks connected to the cluster nodes.

#### Solution:
Make use of the [scrutiny project](https://github.com/analogj/scrutiny) which provides a nice small UI to display the SMART values of the disks that are auto-detected on each node in the cluster.

<img width="1374" height="762" alt="Bildschirmfoto vom 2026-03-26 11-53-28" src="https://github.com/user-attachments/assets/8aacbaa0-d7c9-41a0-93e6-7dd845a60538" />

<img width="1275" height="679" alt="Bildschirmfoto vom 2026-03-26 10-45-24" src="https://github.com/user-attachments/assets/789e88a0-dd94-44df-82ed-a9c427b18b12" />

#### Related Issue(s):
n/a

#### Test plan:
- Download the Helm chart
```
curl -sL "https://github.com/votdev/harvester-charts/archive/refs/heads/scrutiny.tar.gz" \
  | tar -xz --strip-components=2 harvester-charts-scrutiny/charts/scrutiny
```
- Validate the Helm chart
```
helm template scrutiny ./scrutiny -n scrutiny
helm lint ./scrutiny -f values.yaml
helm install scrutiny ./scrutiny -n scrutiny --dry-run --debug
```
- Install the Helm chart
```
helm install scrutiny -n harvester-system --dry-run ./scrutiny
helm install scrutiny -n harvester-system ./scrutiny
```
- Validate installation (on a 3 node cluster)
Check the running pods.
- 3 collector pods
- 1 Influx DB pod
- 1 Web pod
```
kubectl get deployment -n harvester-system
```
- Go to `Service Discovery > Services` in the embedded Rancher. Look out for `scrutiny-web`. Click on the IP in the `Target`column to open the Scrutiny WebUI.

#### Additional documentation or context
- https://suse.slack.com/archives/C02D9459KFW/p1773321565394789