### PR TITLE
fix: update project-scoped permissions to include missing harvester r…

### DIFF
--- a/charts/harvester-rbac/Chart.yaml
+++ b/charts/harvester-rbac/Chart.yaml
@@ -30,7 +30,7 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Harvester RBAC
   catalog.cattle.io/kube-version: ">= 1.31.0-0"
-  catalog.cattle.io/rancher-version: ">= 2.13.0-0"
+  catalog.cattle.io/rancher-version: ">= 2.14.0-0 < 2.15.0-0"
   catalog.cattle.io/release-name: harvester-rbac
   catalog.cattle.io/ui-component: harvester-rbac
 

--- a/charts/harvester-rbac/templates/virt-project-manage.yaml
+++ b/charts/harvester-rbac/templates/virt-project-manage.yaml
@@ -20,6 +20,12 @@ rules:
       - "*"
     verbs:
       - "*"
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
   {{- with .Values.projectRole.virtProjectManage.additionalRules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/harvester-rbac/templates/virt-project-view.yaml
+++ b/charts/harvester-rbac/templates/virt-project-view.yaml
@@ -21,6 +21,20 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - supportbundles
+    verbs:
+      - "*"
   {{- with .Values.projectRole.virtProjectView.additionalRules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:

This PR addresses these two issues:

1. 1.8-rc2 QA test result reported that the project users can't manage or see the backup schedules defined in their namespaces.
1. The value of the `catalog.cattle.io/rancher-version` annotation also doesn't match the Rancher v2.14 convention.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR adds the `harvesterhci.io` API groups to the project roles so that project users can manage/view all namespaced-scoped Harvester resources. This compensates for the missing RBAC rules within the `harvesterhci.io:view` and `harvesterhci.io:edit` cluster roles. Currently, not all the Harvester RBAC rules are aggregated into these two cluster roles. Hence, when the new role templates inherit their RBAC rules from the built-in `view` and `edit` cluster roles, some Harvester permissions are missed.

#### Related Issue(s):

https://github.com/harvester/harvester/issues/7909

#### Test plan:

The full test plan can be found in the HEP at https://github.com/ihcsim/harvester/blob/a06b3e4a6d372c53e19ba2a6081be15d7c81da60/enhancements/20260130-rancher-integration-rbac/test-plan-ui.md

For this change, we only need to retest the `proj-manager` and `proj-viewer` scenarios to make sure they can continue to only manage and see Harvester project-scoped resources. The new addition is that they can now manage and see the backup schedules.

#### Additional documentation or context
