### PR TITLE
fix: update project-scoped permissions to include missing harvester resources

### DIFF
--- a/charts/harvester-rbac/Chart.yaml
+++ b/charts/harvester-rbac/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.1.0
+appVersion: v0.1.1
 
 maintainers:
   - name: harvester

--- a/charts/harvester-rbac/Chart.yaml
+++ b/charts/harvester-rbac/Chart.yaml
@@ -30,7 +30,7 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Harvester RBAC
   catalog.cattle.io/kube-version: ">= 1.31.0-0"
-  catalog.cattle.io/rancher-version: ">= 2.13.0-0"
+  catalog.cattle.io/rancher-version: ">= 2.14.0-0 < 2.15.0-0"
   catalog.cattle.io/release-name: harvester-rbac
   catalog.cattle.io/ui-component: harvester-rbac
 

--- a/charts/harvester-rbac/templates/virt-project-manage.yaml
+++ b/charts/harvester-rbac/templates/virt-project-manage.yaml
@@ -20,6 +20,12 @@ rules:
       - "*"
     verbs:
       - "*"
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
   {{- with .Values.projectRole.virtProjectManage.additionalRules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/harvester-rbac/templates/virt-project-view.yaml
+++ b/charts/harvester-rbac/templates/virt-project-view.yaml
@@ -21,6 +21,20 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - supportbundles
+    verbs:
+      - "*"
   {{- with .Values.projectRole.virtProjectView.additionalRules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
Bump harvester-rbac chart. Cherry-pick from https://github.com/harvester/charts/pull/503.
