### PR TITLE
Extend harvester-cloud-provider chart

### DIFF
--- a/charts/harvester-cloud-provider/questions.yml
+++ b/charts/harvester-cloud-provider/questions.yml
@@ -5,7 +5,28 @@ namespace: kube-system
 questions:
 - variable: cloudConfigPath
   label: Cloud config file path
-  description: "Specify the path of the cloud config."
+  description: "Specify the absolute path to the cloud-config file on the host. This field takes absolute priority; if set, it MUST point to a valid file. To use the Secret or fallback options below, this field must be left empty."
   group: "Default"
+  type: string
+  default: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
+
+- variable: cloudConfig.secretName
+  label: Cloud Config Secret Name
+  description: "The name of the Kubernetes Secret containing the cloud provider configuration. Active only if 'Cloud config file path' is empty."
+  group: "Cloud Config"
+  type: string
+  default: ""
+
+- variable: cloudConfig.secretKey
+  label: Cloud Config Secret Key
+  description: "The key within the Secret that holds the configuration data. Defaults to 'cloud-config'."
+  group: "Cloud Config"
+  type: string
+  default: "cloud-config"
+
+- variable: cloudConfig.hostPath
+  label: Cloud Config Fallback Host Path
+  description: "The host file path used if 'Cloud config file path' is empty and no Secret is provided. Must be a direct path to a file."
+  group: "Cloud Config"
   type: string
   default: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"

--- a/charts/harvester-cloud-provider/questions.yml
+++ b/charts/harvester-cloud-provider/questions.yml
@@ -30,3 +30,10 @@ questions:
   group: "Cloud Config"
   type: string
   default: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
+
+- variable: extraArgs
+  label: Extra Arguments
+  description: "Additional CLI flags for the harvester-cloud-provider (e.g., --v=5 or --controllers=...). Click 'Add' to define multiple flags."
+  group: "Advanced"
+  type: array
+  default: []

--- a/charts/harvester-cloud-provider/questions.yml
+++ b/charts/harvester-cloud-provider/questions.yml
@@ -30,3 +30,19 @@ questions:
   group: "Cloud Config"
   type: string
   default: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
+
+- variable: extraArgs
+  label: Extra Arguments
+  description: >-
+    Additional CLI flags for the deployment container. Used for Multi-NIC/IP setups
+    or to disable specific controllers. (Note: Avoid internal quotes like --flag="value"; use --flag=value).
+    * --controllers: Define active controllers. Omit 'loadbalancer' to disable Harvester LB support.
+    * --management-network: Explicitly set network name (e.g., default/vlan-100).
+    * --node-ip-cidr: CIDR range for accurate IP selection.
+    * --node-exclude-ip-ranges: Blacklist IPs/subnets (comma-separated); excluded IPs won't be reported as Node IPs.
+    * --disable-annotation-alpha-provided-ip-addr=true: Ignore legacy annotations in favor of CIDR logic.
+    * --loadbalancer-network: (Experimental) Restrict LoadBalancers to a specific network.
+    * --show-full-help-on-error=true: Display full help menu on startup flag errors.
+  group: "Advanced"
+  type: array
+  default: []

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -36,8 +36,13 @@ spec:
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - mountPath: /etc/kubernetes/cloud-config
-              name: cloud-config
+            - name: cloud-config
+              readOnly: true
+              {{- if or .Values.cloudConfig.secretName .Values.cloudConfig.hostPath }}
+              mountPath: /etc/kubernetes/
+              {{- else }}
+              mountPath: /etc/kubernetes/cloud-config
+              {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -52,6 +57,15 @@ spec:
       {{- end }}
       volumes:
         - name: cloud-config
+        {{- if .Values.cloudConfig.secretName }}
+          secret:
+            secretName: {{ .Values.cloudConfig.secretName }}
+        {{- else if .Values.cloudConfig.hostPath }}
           hostPath:
-            path: {{ required "A valid cloudConfigPath is required!" .Values.cloudConfigPath }}
+            path: {{ .Values.cloudConfig.hostPath }}
             type: File
+        {{- else }}
+          hostPath:
+            path: {{ required "A valid cloudConfigPath, cloudConfig.secretName or cloudConfig.hostPath is required!" .Values.cloudConfigPath }}
+            type: DirectoryOrCreate
+        {{- end }}

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -37,11 +37,14 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: cloud-config
-              readOnly: true
-              {{- if or .Values.cloudConfig.secretName .Values.cloudConfig.hostPath }}
-              mountPath: /etc/kubernetes/
-              {{- else }}
               mountPath: /etc/kubernetes/cloud-config
+              readOnly: true
+              {{- if .Values.cloudConfigPath }}
+              subPath: {{ base .Values.cloudConfigPath }}
+              {{- else if .Values.cloudConfig.secretName }}
+              subPath: {{ .Values.cloudConfig.secretKey | default "cloud-config" }}
+              {{- else if .Values.cloudConfig.hostPath }}
+              subPath: {{ base .Values.cloudConfig.hostPath }}
               {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -57,15 +60,20 @@ spec:
       {{- end }}
       volumes:
         - name: cloud-config
-        {{- if .Values.cloudConfig.secretName }}
+        {{- if .Values.cloudConfigPath }}
+          hostPath:
+            path: {{ .Values.cloudConfigPath }}
+            type: File
+        {{- else if .Values.cloudConfig.secretName }}
           secret:
             secretName: {{ .Values.cloudConfig.secretName }}
+            items:
+              - key: {{ .Values.cloudConfig.secretKey | default "cloud-config" }}
+                path: cloud-config
         {{- else if .Values.cloudConfig.hostPath }}
           hostPath:
             path: {{ .Values.cloudConfig.hostPath }}
             type: File
         {{- else }}
-          hostPath:
-            path: {{ required "A valid cloudConfigPath, cloudConfig.secretName or cloudConfig.hostPath is required!" .Values.cloudConfigPath }}
-            type: DirectoryOrCreate
+          {{- fail "A valid cloudConfigPath, secretName, or hostPath is required." -}}
         {{- end }}

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "harvester-cloud-provider.labels" . | nindent 4 }}
   name: {{ include "harvester-cloud-provider.name" . }}
 spec:
-  replicas: {{ .Values.replicasCount}}
+  replicas: {{ .Values.replicasCount }}
   selector:
     matchLabels:
   {{- include "harvester-cloud-provider.selectorLabels" . | nindent 6 }}
@@ -30,7 +30,11 @@ spec:
             - --cloud-config=/etc/kubernetes/cloud-config
             {{- if ne .Values.global.cattle.clusterName "" }}
             - --cluster-name={{ .Values.global.cattle.clusterName }}
-          {{- end }}
+            {{- end }}
+            {{- /* Inject additional user-defined CLI arguments */ -}}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           command:
             - harvester-cloud-provider
           resources:

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -39,12 +39,8 @@ spec:
             - name: cloud-config
               mountPath: /etc/kubernetes/cloud-config
               readOnly: true
-              {{- if .Values.cloudConfigPath }}
-              subPath: {{ base .Values.cloudConfigPath }}
-              {{- else if .Values.cloudConfig.secretName }}
-              subPath: {{ .Values.cloudConfig.secretKey | default "cloud-config" }}
-              {{- else if .Values.cloudConfig.hostPath }}
-              subPath: {{ base .Values.cloudConfig.hostPath }}
+              {{- if and (not .Values.cloudConfigPath) .Values.cloudConfig.secretName }}
+              subPath: cloud-config
               {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -75,5 +71,5 @@ spec:
             path: {{ .Values.cloudConfig.hostPath }}
             type: File
         {{- else }}
-          {{- fail "A valid cloudConfigPath, secretName, or hostPath is required." -}}
+          {{- fail "A valid cloudConfigPath, cloudConfig.secretName, or cloudConfig.hostPath is required." -}}
         {{- end }}

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "harvester-cloud-provider.labels" . | nindent 4 }}
   name: {{ include "harvester-cloud-provider.name" . }}
 spec:
-  replicas: {{ .Values.replicasCount}}
+  replicas: {{ .Values.replicasCount }}
   selector:
     matchLabels:
   {{- include "harvester-cloud-provider.selectorLabels" . | nindent 6 }}
@@ -30,7 +30,18 @@ spec:
             - --cloud-config=/etc/kubernetes/cloud-config
             {{- if ne .Values.global.cattle.clusterName "" }}
             - --cluster-name={{ .Values.global.cattle.clusterName }}
-          {{- end }}
+            {{- end }}
+            {{- /*
+               CRITICAL: Use 'range' instead of 'toYaml' to inject extraArgs (user-defined CLI arguments).
+               This ensures that the YAML parser strips any outer quotes from values.yaml,
+               passing the raw flag/value directly to the container.
+               Example:
+                 values.yaml:   - "--management-network=default/vlan-100"
+                 rendered here: - --management-network=default/vlan-100
+            */ -}}
+            {{- range .Values.extraArgs }}
+            - {{ . }}
+            {{- end }}
           command:
             - harvester-cloud-provider
           resources:

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -37,11 +37,10 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: cloud-config
-              readOnly: true
-              {{- if or .Values.cloudConfig.secretName .Values.cloudConfig.hostPath }}
-              mountPath: /etc/kubernetes/
-              {{- else }}
               mountPath: /etc/kubernetes/cloud-config
+              readOnly: true
+              {{- if and (not .Values.cloudConfigPath) .Values.cloudConfig.secretName }}
+              subPath: cloud-config
               {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -57,15 +56,20 @@ spec:
       {{- end }}
       volumes:
         - name: cloud-config
-        {{- if .Values.cloudConfig.secretName }}
+        {{- if .Values.cloudConfigPath }}
+          hostPath:
+            path: {{ .Values.cloudConfigPath }}
+            type: File
+        {{- else if .Values.cloudConfig.secretName }}
           secret:
             secretName: {{ .Values.cloudConfig.secretName }}
+            items:
+              - key: {{ .Values.cloudConfig.secretKey | default "cloud-config" }}
+                path: cloud-config
         {{- else if .Values.cloudConfig.hostPath }}
           hostPath:
             path: {{ .Values.cloudConfig.hostPath }}
             type: File
         {{- else }}
-          hostPath:
-            path: {{ required "A valid cloudConfigPath, cloudConfig.secretName or cloudConfig.hostPath is required!" .Values.cloudConfigPath }}
-            type: DirectoryOrCreate
+          {{- fail "A valid cloudConfigPath, cloudConfig.secretName, or cloudConfig.hostPath is required." -}}
         {{- end }}

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -11,6 +11,9 @@ image:
   tag: "master-head"
 
 cloudConfigPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
+cloudConfig:
+  secretName: ""
+  hostPath: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -10,9 +10,16 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "master-head"
 
+# Configuration Precedence:
+# The system looks for cloud configuration in the following order:
+#  cloudConfigPath (Highest priority)
+#  cloudConfig.secretName
+#  cloudConfig.hostPath (Fallback)
 cloudConfigPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 cloudConfig:
   secretName: ""
+  # Default key
+  secretKey: "cloud-config"
   hostPath: ""
 
 imagePullSecrets: []

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -11,16 +11,28 @@ image:
   tag: "master-head"
 
 # Configuration Precedence:
-# The system looks for cloud configuration in the following order:
-#  cloudConfigPath (Highest priority)
-#  cloudConfig.secretName
-#  cloudConfig.hostPath (Fallback)
+# 1. cloudConfigPath (Primary): Used by most existing systems.
+#    This field takes absolute priority and MUST point to a valid file on the host.
+#    To use the 'cloudConfig' block below, this field must be empty ("").
+# 2. cloudConfig.secretName: Modern method using a Kubernetes Secret.
+#    - cloudConfig.secretKey: The key within the Secret containing the config file data.
+#      Defaults to "cloud-config".
+# 3. cloudConfig.hostPath: Final fallback. MUST point to a valid file on the host.
+
+# Absolute path to the cloud provider config file (Primary method)
+# Note: If this is set, it must be a file; directories will cause the pod to fail.
 cloudConfigPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
+
 cloudConfig:
+  # Name of the Secret containing the config (Active only if cloudConfigPath is empty)
   secretName: ""
-  # Default key
+
+  # The key within the Secret to retrieve. Defaults to "cloud-config".
   secretKey: "cloud-config"
-  hostPath: ""
+
+  # Fallback host file path (Used only if cloudConfigPath is empty and secretName is missing)
+  # Must be a direct path to a file.
+  hostPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -2,7 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Number of replicas for the cloud provider.
 replicasCount: 1
+
+# -- Additional command line arguments to pass to the harvester-cloud-provider binary.
+# Must be provided as a YAML list of strings.
+# Example:
+# extraArgs:
+#   - "--controllers=cloud-node-controller,cloud-node-lifecycle-controller,node-route-controller"
+extraArgs: []
 
 image:
   repository: rancher/harvester-cloud-provider

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -2,7 +2,47 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Number of replicas for the cloud provider.
 replicasCount: 1
+
+# -- Additional command line arguments to pass to the harvester-cloud-provider deployment container.
+# Arguments must be provided as a YAML list of strings.
+#
+# Use these to configure both the Cloud Provider framework and Harvester-specific logic.
+#
+# 1. Framework & Controller Flags:
+#    - --controllers: List of controllers to enable. Omit a controller to disable it.
+#    - --v: Verbosity level for logging (e.g., "--v=5" for debug).
+#
+# 2. Harvester-specific Flags (Networking & IP Selection):
+#    - --management-network: Defines the network name to bypass "first-hit" selection
+#      logic in multi-NIC environments.
+#    - --node-ip-cidr: CIDR range to ensure precise IP selection in multi-IP setups.
+#    - --node-exclude-ip-ranges: Blacklist specific IPs or subnets (comma-separated).
+#      Any IP on this list will NOT be reported as an InternalIP or ExternalIP.
+#    - --disable-annotation-alpha-provided-ip-addr: (bool) Set to true to disable legacy
+#      alpha annotations and force modern CIDR-based selection.
+#    - --loadbalancer-network: (Experimental) Restricts LoadBalancers to a specific network.
+#    - --show-full-help-on-error: (bool) Set to true to automatically display the
+#      comprehensive help menu if a flag-related error occurs during startup.
+#
+# Example 1 (Recommended for Multi-NIC / Multi-IP setups with exclusions):
+# extraArgs:
+#   - "--management-network=default/vlan-100"
+#   - "--node-ip-cidr=192.168.1.0/24"
+#   - "--node-exclude-ip-ranges=192.168.1.1,192.168.1.254"
+#   - "--disable-annotation-alpha-provided-ip-addr=true"
+#   - "--show-full-help-on-error=true"
+#
+# Example 2 (Disable the LoadBalancer controller from harvester-cloud-provider):
+# extraArgs:
+#   - "--controllers=cloud-node-controller,cloud-node-lifecycle-controller,node-route-controller"
+#
+# NOTE: Avoid using internal quotes for values. The runtime passes these strings directly.
+#
+# Bad:  - "--cluster-name=\"my-cluster\""
+# Good: - "--cluster-name=my-cluster"
+extraArgs: []
 
 image:
   repository: rancher/harvester-cloud-provider

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -10,10 +10,29 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "master-head"
 
+# Configuration Precedence:
+# 1. cloudConfigPath (Primary): Used by most existing systems.
+#    This field takes absolute priority and MUST point to a valid file on the host.
+#    To use the 'cloudConfig' block below, this field must be empty ("").
+# 2. cloudConfig.secretName: Modern method using a Kubernetes Secret.
+#    - cloudConfig.secretKey: The key within the Secret containing the config file data.
+#      Defaults to "cloud-config".
+# 3. cloudConfig.hostPath: Final fallback. MUST point to a valid file on the host.
+
+# Absolute path to the cloud provider config file (Primary method)
+# Note: If this is set, it must be a file; directories will cause the pod to fail.
 cloudConfigPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
+
 cloudConfig:
+  # Name of the Secret containing the config (Active only if cloudConfigPath is empty)
   secretName: ""
-  hostPath: ""
+
+  # The key within the Secret to retrieve. Defaults to "cloud-config".
+  secretKey: "cloud-config"
+
+  # Fallback host file path (Used only if cloudConfigPath is empty and secretName is missing)
+  # Must be a direct path to a file.
+  hostPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

commits:

- Add support for secrets and host path similar to harvester-csi-driver
- Add extraArgs to follow user's guide about which controller should run on cloud-provider;  also support harvester-cloud-provider newly added features via PR https://github.com/harvester/cloud-provider-harvester/pull/74

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

1. The `harvester-cloud-provider` only supports using `cloudConfigPath` to inject the config.
2. Lack of options to toggle cloud-provider framework related plugins, controllers.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add new option `cloudConfig` to support secret, but the original `cloudConfigPath` is still in highest priority to use, which ensures the legacy usage and Rancher UI integration (which injects value to cloudConfigPath) are not broken.


With the updated `question.yaml`, Rancher UI shows:

<img width="2078" height="714" alt="image" src="https://github.com/user-attachments/assets/c1fd64cd-8e4f-4ff2-8f22-2ee48ffd5dd3" />



#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

controller side PR: https://github.com/harvester/cloud-provider-harvester/pull/74
EPIC: https://github.com/harvester/harvester/issues/10068


https://github.com/harvester/charts/pull/439
https://github.com/harvester/harvester/issues/9503

#### Test plan:
<!-- Describe the test plan by steps. -->

This PR will be tested with https://github.com/harvester/charts/pull/524 and https://github.com/harvester/cloud-provider-harvester/pull/74 together.

The test steps are a bit complex, if you want to run this, refer https://github.com/w13915984028/harvester-develop-summary/blob/main/dev-ref/how-to-set-a-local-helm-repo-to-test-charts.md#202605-test-hcp-chart-with-controller

1. Prepare a new HCP chart and serve it locally
1. Prepare a guest cluster
1. Set up the local repo and refresh to get the HCP chart
1. Upgrade the HCP chart, and update the chart values to test more

Test report:

**1. The passing of extraArgs**

Via an extraArgs `--node-ip-cidr=192.168.122.0/24`, even when the node is booted with both ipv4, ipv6 address, the HCP reports to k8s node correctly with `192.168.122.158` as InternalIP, `2001:db8:cafe::11f ` as ExternalIP.

This relies on controller PR https://github.com/harvester/cloud-provider-harvester/pull/74 as well. Controller PR has tested those params directly. Chart PR https://github.com/harvester/charts/pull/511 focus on pass params to container correctly.

```
root@gc5-pool1-sjtlm-8p65q:~# logs -n kube-system harvester-cloud-provider-76f6c445b9-667br
time="2026-05-07T10:08:07Z" level=info msg="cloudprovider.harvesterhci.io effective configurations: --cluster-name=gc5 --controllers=* --management-network= --node-ip-cidr=192.168.122.0/24 --node-exclude-ip-ranges= --disable-annotation-alpha-provided-ip-addr=false --loadbalancer-network= --disable-vmi-controller=false --show-full-help-on-error=false"

time="2026-05-07T10:08:27Z" level=info msg="Successfully resolved (fetched, checked and filtered) addresses for node gc5-pool1-sjtlm-8p65q via its VMI default/gc5-pool1-sjtlm-8p65q on network nic-0: [{InternalIP 192.168.122.158} {ExternalIP 2001:db8:cafe::11f} {Hostname gc5-pool1-sjtlm-8p65q}]"


root@gc5-pool1-sjtlm-8p65q:~#  get nodes -A -owide
NAME                    STATUS   ROLES                       AGE   VERSION          INTERNAL-IP       EXTERNAL-IP          OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME


gc5-pool1-sjtlm-8p65q   Ready    control-plane,etcd,worker   44h   v1.35.3+rke2r3   192.168.122.158   2001:db8:cafe::11f   Ubuntu 22.04.5 LTS   5.15.0-177-generic   containerd://2.2.2-k3s1

```

**2. The secret based cloud-config**

2.1 upgrade the exising HCP chart like above, it is still using the old `.Values.cloudConfigPath`, works correctly

2.2 on the guest cluster, construct a secret on the `kube-system` namespace, and update the chart, works well

set `cloudConfigPath` to be empty,  set `cloudConfig.secretName` to the secret name like `hcp-cluster-config`, set `cloudConfig.secretKey` to the secret key like `config`   (note: if secret name or key does not match, then the mount will be rejected by k8s)

a quick example is:

```
your-guest-cluster$ kubectl create secret generic hcp-cluster-config --from-file=config=/var/lib/rancher/rke2/etc/config-files/cloud-provider-config   --namespace kube-system

secretName: hcp-cluster-config
secretKey: config
secret namespace: kube-system

```


<details>

<summary>construct a secret and update the chart to use this secret</summary>

<img width="2490" height="1224" alt="image" src="https://github.com/user-attachments/assets/f4cf0c0f-7d85-4478-b420-0300ce93ea1d" />


```

1. on guest cluster to create a secret from the exsting config file

kubectl create secret generic hcp-cluster-config --from-file=config=/var/lib/rancher/rke2/etc/config-files/cloud-provider-config   --namespace kube-system

2. via Rancher UI chart upgrade, and edit yaml to clean cloudConfigPath,  set secretName and secretKey

affinity:
...
cloudConfig:
  hostPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
  secretKey: config
  secretName: hcp-cluster-config
cloudConfigPath: ''

kubectl get pods  -n kube-system harvester-cloud-provider-b895bfd57-nhcbg -oyaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2026-05-07T18:50:34Z"
  generateName: harvester-cloud-provider-b895bfd57-
...

  name: harvester-cloud-provider-b895bfd57-nhcbg
  namespace: kube-system
...
spec:
...
  containers:
  - args:
    - --cloud-config=/etc/kubernetes/cloud-config
    - --cluster-name=gc3
    command:
    - harvester-cloud-provider
...
    volumeMounts:
    - mountPath: /etc/kubernetes/cloud-config
      name: cloud-config
      readOnly: true
      subPath: cloud-config
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-qzpqm
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  hostNetwork: true
  nodeName: gc3-pool1-vmdz2-ck7lj
...
  volumes:
  - name: cloud-config
    secret:
      defaultMode: 420
      items:
      - key: config
        path: cloud-config
      secretName: hcp-cluster-config
...



root@gc3-pool1-vmdz2-ck7lj:~# kubectl get app -n kube-system harvester-cloud-provider
NAME                       CHART                      VERSION            RELEASE NAME               RELEASE VERSION   STATUS
harvester-cloud-provider   harvester-cloud-provider   109.0.1+up0.2.12   harvester-cloud-provider   4                 deployed

root@gc3-pool1-vmdz2-ck7lj:~# kubectl get app -n kube-system harvester-cloud-provider -oyaml
apiVersion: catalog.cattle.io/v1
kind: App
metadata:
  annotations:
    objectset.rio.cattle.io/applied: H4sIA...LAAA
    objectset.rio.cattle.io/id: helm-app
    objectset.rio.cattle.io/owner-gvk: /v1, Kind=Secret
    objectset.rio.cattle.io/owner-name: sh.helm.release.v1.harvester-cloud-provider.v4
    objectset.rio.cattle.io/owner-namespace: kube-system
  creationTimestamp: "2026-05-07T18:39:56Z"
  generation: 5
  labels:
    catalog.cattle.io/cluster-repo-name: my-local
    objectset.rio.cattle.io/hash: 348a1bf17474e0233aec1cb41ede98fd20abf9bd
  name: harvester-cloud-provider
  namespace: kube-system

spec:
  chart:
    metadata:
      annotations:
        catalog.cattle.io/certified: rancher
        catalog.cattle.io/display-name: Harvester Cloud Provider
...
        catalog.cattle.io/upstream-version: 0.2.12
      apiVersion: v2
      appVersion: v0.2.5

      name: harvester-cloud-provider
      type: application
      version: 109.0.1+up0.2.12
  helmVersion: 3
  info:
    description: Upgrade complete
    firstDeployed: "2026-05-07T18:24:02Z"
    lastDeployed: "2026-05-07T18:50:33Z"
    status: deployed
  name: harvester-cloud-provider
  namespace: kube-system




```

</details>


2.3 construct a new sceret when deployment the guest cluster

the solution to inject a secret:

<details>

<summary>Inject secret via rke2 additional manifest</summary>

Via `Additional Manifest`, we can inject a secret to work as the cloud-provider-harvester config.

But there is a checken-and-egg issue, notice below `cloud-provider-config: secret://fleet-default:harvesterconfigl8d7d`, this secret is the source, it is generated on `Rancher Manager` when you create the guest cluster.

So we can do it via two-steps on UI:

(1) Create the guest cluster as normal, save, then get the content of secret from `fleet-default/harvesterconfigl8d7d`

(2) Edit the config, past the content like below secret. Then this secret could be used as the HCP cloud-config.

2.2 has proved this works.


<img width="2248" height="1534" alt="image" src="https://github.com/user-attachments/assets/79981eb6-2937-4832-afff-abb5856a1e0a" />




```
...
spec:
  cloudCredentialSecretName: cattle-global-data:cc-xf9nm
  kubernetesVersion: v1.35.4+rke2r1
  localClusterAuthEndpoint: {}
  rkeConfig:
    additionalManifest: |-
      apiVersion: v1
      kind: Secret
      metadata:
        name: hcp-config1
        namespace: kube-system
      type: Opaque
      data:
        config: YXBpVmVyc2lvb...XV6Zwo=
    chartValues:
      harvester-cloud-provider: {}
      rke2-calico: {}
      rke2-ingress-nginx: {}
      rke2-traefik: {}
    dataDirectories: {}
    etcd:
      snapshotRetention: 5
      snapshotScheduleCron: 0 */5 * * *
    machineGlobalConfig:
      cni: calico
      disable-kube-proxy: false
      etcd-expose-metrics: false
      ingress-controller: traefik
    machinePoolDefaults: {}
    machinePools:
      - controlPlaneRole: true
        drainBeforeDelete: true
        dynamicSchemaSpec: >-
      ...
          vm namespace"}}}
        etcdRole: true
        machineConfigRef:
          kind: HarvesterConfig
          name: nc-gc5-pool1-9bq6k
        name: pool1
        quantity: 1
        unhealthyNodeTimeout: 0s
        workerRole: true
    machineSelectorConfig:
      - config:
          cloud-provider-config: secret://fleet-default:harvesterconfigl8d7d
          cloud-provider-name: harvester
          protect-kernel-defaults: false
    networking: {}
    registries: {}
    upgradeStrategy:
...

</details>


#### Additional documentation or context
