### PR TITLE
fix(harvester-upgrade-manager): fallback image tag to Chart.AppVersion

### DIFF
--- a/charts/harvester-upgrade-manager/templates/manager/manager.yaml
+++ b/charts/harvester-upgrade-manager/templates/manager/manager.yaml
@@ -67,7 +67,7 @@ spec:
           {{- else }}
           []
           {{- end }}
-        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The image tag used by the Harvester Upgrade Manager currently does not have a fallback value. This makes the chart developer no choices but to specify the image tag used in the values.yaml file. However, this causes trouble for the release automation. Ideally, this specific chart should align the behavior with others.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add a default, which falls back to the `Chart.AppVersion` value.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

A subsequent PR targeting the `release` branch will handle the image tag dropping in the values.yaml file.