### PR TITLE
chore: bump kubeovn-operator to 1.15.4

### DIFF
--- a/charts/kubeovn-operator-crd/Chart.yaml
+++ b/charts/kubeovn-operator-crd/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.4-dev.0
+version: 1.15.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.15.4-dev.0
+appVersion: v1.15.4
 
 maintainers:
 - name: harvester

--- a/charts/kubeovn-operator/Chart.yaml
+++ b/charts/kubeovn-operator/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.4-dev.0
+version: 1.15.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.15.4-dev.0
+appVersion: v1.15.4
 
 maintainers:
 - name: harvester


### PR DESCRIPTION
Formal release for kubeovn-operator and kubeovn-operator-crd charts 1.15.4