### PR TITLE
Remove 1.8.0 for harvester-upgrade-manager

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -7556,23 +7556,6 @@ entries:
   - annotations:
       kubebuilder.io/generated-by: kubebuilder
     apiVersion: v2
-    appVersion: v1.8.0
-    created: "2026-04-24T08:54:26.480962976Z"
-    description: A Helm chart to distribute harvester-upgrade-manager
-    digest: abec720f5e47d94507878936582b52d222e2d187964860d651e76842c0643ed1
-    keywords:
-    - kubernetes
-    - operator
-    maintainers:
-    - name: harvester
-    name: harvester-upgrade-manager
-    type: application
-    urls:
-    - https://github.com/harvester/charts/releases/download/harvester-upgrade-manager-1.8.0/harvester-upgrade-manager-1.8.0.tgz
-    version: 1.8.0
-  - annotations:
-      kubebuilder.io/generated-by: kubebuilder
-    apiVersion: v2
     appVersion: v1.8.0-rc6.r3
     created: "2026-04-23T08:53:23.931050815Z"
     description: A Helm chart to distribute harvester-upgrade-manager


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

harvester-upgrade-manager chart 1.8.0 needs to be re-released due to a missing specific commit.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Remove the existing 1.8.0 version.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
