### PR TITLE
charts: bump csi-driver-lvm and vm-dhcp-controller to v1.9.0.dev.0

### DIFF
--- a/charts/harvester-csi-driver-lvm/Chart.yaml
+++ b/charts/harvester-csi-driver-lvm/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 1.9.0-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.2"
+appVersion: "main-head"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-csi-driver-lvm/templates/csi.yaml
+++ b/charts/harvester-csi-driver-lvm/templates/csi.yaml
@@ -55,7 +55,7 @@ spec:
         - --hostwritepath={{ .Values.lvm.hostWritePath }}
         - --nodeid=$(KUBE_NODE_NAME)
         - --namespace={{ .Release.Namespace }}
-        - --provisionerimage={{ .Values.provisionerImage.repository }}:{{ .Values.provisionerImage.tag }}
+        - --provisionerimage={{ .Values.provisionerImage.repository }}:{{ .Values.provisionerImage.tag | default .Chart.AppVersion }}
         - --pullpolicy={{ .Values.provisionerImage.pullPolicy }}
         env:
         - name: KUBE_NODE_NAME
@@ -63,7 +63,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: "{{ .Values.pluginImage.repository }}:{{ .Values.pluginImage.tag }}"
+        image: "{{ .Values.pluginImage.repository }}:{{ .Values.pluginImage.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.pluginImage.pullPolicy }}
         livenessProbe:
           failureThreshold: 5

--- a/charts/harvester-csi-driver-lvm/values.yaml
+++ b/charts/harvester-csi-driver-lvm/values.yaml
@@ -6,18 +6,17 @@ pluginImage:
   repository: rancher/harvester-lvm-csi-plugin
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.2"
+  tag: ""
 
 provisionerImage:
   repository: rancher/harvester-lvm-provisioner
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.2"
+  tag: ""
 
 hookImage:
   repository: rancher/kubectl
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: "v1.32.3"
 
 nameOverride: ""
@@ -35,7 +34,7 @@ webhook:
     repository: rancher/harvester-lvm-csi-driver-webhook
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.1.2"
+    tag: ""
   httpsPort: 8443
 
 rbac:

--- a/charts/harvester-vm-dhcp-controller/Chart.yaml
+++ b/charts/harvester-vm-dhcp-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.9.0-dev.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.6.0"
+appVersion: "main-head"
 
 maintainers:
 - name: harvester


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

@WebberHuang1118 found that csi-driver-lvm on `release` branch is currently using an old version: https://github.com/harvester/csi-driver-lvm/releases/tag/v0.1.2

Likewise, vm-dhcp-controller is also on an old version: https://github.com/harvester/vm-dhcp-controller/releases/tag/v1.6.0


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Thank @WebberHuang1118 for the PR https://github.com/harvester/charts/pull/535. In this PR, we bump `csi-driver-lvm` and `vm-dhcp-controller` to `v1.9.0.dev.0`. They should start using nightly build on `release` branch.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
