### PR TITLE
charts: move `rancher/kuberlr-kubectl` to v7.0.3 (v1.35.2)

### DIFF
--- a/charts/harvester-csi-driver-lvm/values.yaml
+++ b/charts/harvester-csi-driver-lvm/values.yaml
@@ -15,9 +15,9 @@ provisionerImage:
   tag: "main-head"
 
 hookImage:
-  repository: rancher/kuberlr-kubectl  # v1.32.13
+  repository: rancher/kuberlr-kubectl  # v1.35.2
   pullPolicy: IfNotPresent
-  tag: "v4.0.7"
+  tag: "v7.0.3"
 
 nameOverride: ""
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
move `rancher/kuberlr-kubectl` to v7.0.3 (v1.35.2)

#### Solution:
move `rancher/kuberlr-kubectl` to v7.0.3 (v1.35.2)

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
