### PR TITLE
Treat cloud-config secret as first prioty if it is set

### DIFF
--- a/charts/harvester-cloud-provider/questions.yml
+++ b/charts/harvester-cloud-provider/questions.yml
@@ -5,14 +5,14 @@ namespace: kube-system
 questions:
 - variable: cloudConfigPath
   label: Cloud config file path
-  description: "Specify the absolute path to the cloud-config file on the host. This field takes absolute priority; if set, it MUST point to a valid file. To use the Secret or fallback options below, this field must be left empty."
+  description: "Specify the absolute path to the cloud-config file on the host. This serves as the default for legacy deployments, but will be overridden if a Cloud Config Secret Name is explicitly provided."
   group: "Default"
   type: string
   default: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 
 - variable: cloudConfig.secretName
   label: Cloud Config Secret Name
-  description: "The name of the Kubernetes Secret containing the cloud provider configuration. Active only if 'Cloud config file path' is empty."
+  description: "The name of the Kubernetes Secret containing the cloud provider configuration. If explicitly set, this takes absolute priority over the host file path."
   group: "Cloud Config"
   type: string
   default: ""
@@ -23,13 +23,6 @@ questions:
   group: "Cloud Config"
   type: string
   default: "cloud-config"
-
-- variable: cloudConfig.hostPath
-  label: Cloud Config Fallback Host Path
-  description: "The host file path used if 'Cloud config file path' is empty and no Secret is provided. Must be a direct path to a file."
-  group: "Cloud Config"
-  type: string
-  default: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 
 - variable: extraArgs
   label: Extra Arguments

--- a/charts/harvester-cloud-provider/templates/deployment.yaml
+++ b/charts/harvester-cloud-provider/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: cloud-config
               mountPath: /etc/kubernetes/cloud-config
               readOnly: true
-              {{- if and (not .Values.cloudConfigPath) .Values.cloudConfig.secretName }}
+              {{- if .Values.cloudConfig.secretName }}
               subPath: cloud-config
               {{- end }}
       {{- with .Values.nodeSelector }}
@@ -67,16 +67,16 @@ spec:
       {{- end }}
       volumes:
         - name: cloud-config
-        {{- if .Values.cloudConfigPath }}
-          hostPath:
-            path: {{ .Values.cloudConfigPath }}
-            type: File
-        {{- else if .Values.cloudConfig.secretName }}
+        {{- if .Values.cloudConfig.secretName }}
           secret:
             secretName: {{ .Values.cloudConfig.secretName }}
             items:
               - key: {{ .Values.cloudConfig.secretKey | default "cloud-config" }}
                 path: cloud-config
+        {{- else if .Values.cloudConfigPath }}
+          hostPath:
+            path: {{ .Values.cloudConfigPath }}
+            type: File
         {{- else if .Values.cloudConfig.hostPath }}
           hostPath:
             path: {{ .Values.cloudConfig.hostPath }}

--- a/charts/harvester-cloud-provider/values.yaml
+++ b/charts/harvester-cloud-provider/values.yaml
@@ -50,27 +50,23 @@ image:
   tag: "master-head"
 
 # Configuration Precedence:
-# 1. cloudConfigPath (Primary): Used by most existing systems.
-#    This field takes absolute priority and MUST point to a valid file on the host.
-#    To use the 'cloudConfig' block below, this field must be empty ("").
-# 2. cloudConfig.secretName: Modern method using a Kubernetes Secret.
+# 1. cloudConfig.secretName: Primary priority for new deployments. If explicitly set,
+#    this takes absolute precedence over all other options and mounts a Kubernetes Secret.
 #    - cloudConfig.secretKey: The key within the Secret containing the config file data.
 #      Defaults to "cloud-config".
-# 3. cloudConfig.hostPath: Final fallback. MUST point to a valid file on the host.
+# 2. cloudConfigPath (Legacy/Default): Used for backward compatibility with existing systems.
+#    If no secretName is set, this field takes priority.
+# 3. cloudConfig.hostPath: Final fallback / Deprecation Placeholder. Hidden from the UI to avoid confusion.
+#    Only evaluated if secretName is empty AND cloudConfigPath is manually cleared out ("") in the raw values.yaml.
+#    This serves as a structural placeholder to safely transition from root-level 'cloudConfigPath'
+#    to a nested 'cloudConfig.hostPath' structure in future major releases.
 
-# Absolute path to the cloud provider config file (Primary method)
-# Note: If this is set, it must be a file; directories will cause the pod to fail.
+# Note: Any host path used below must be a direct path to a file; directories will cause pod failure.
 cloudConfigPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 
 cloudConfig:
-  # Name of the Secret containing the config (Active only if cloudConfigPath is empty)
   secretName: ""
-
-  # The key within the Secret to retrieve. Defaults to "cloud-config".
   secretKey: "cloud-config"
-
-  # Fallback host file path (Used only if cloudConfigPath is empty and secretName is missing)
-  # Must be a direct path to a file.
   hostPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 
 imagePullSecrets: []


### PR DESCRIPTION
  The secret based cloud-config does not exist on legacy deployments, on new chart release,
  if user set it, then take it.
  
  This keeps the backward compatibilty and also ensures the new secret based cloud-config is easy to use, user is not forced to clear legacy information.

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The default `/var/lib/rancher/rke2/etc/config-files/cloud-provider-config` is hard to be cleared on Rancher UI, which beats the secret based cloud-config.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1.Treat cloud-config secret as first prioty if it is set

  It does not exist on legacy deployments, on new chart release, if user set it, then take it.
    
2. Remove the `cloudConfig.hostPath` from questions.yaml, to avoid confusing users.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10225

#### Test plan:
<!-- Describe the test plan by steps. -->

Per https://github.com/harvester/harvester/issues/10225#issuecomment-4753722530

#### Additional documentation or context
Observed when testing https://github.com/harvester/harvester/issues/10225#issuecomment-4753722530

Last minor update before cut https://github.com/harvester/harvester/issues/10068