### PR TITLE
filter node affinity criteria for nvidia-driver-runtime

### DIFF
--- a/charts/nvidia-driver-runtime/values.yaml
+++ b/charts/nvidia-driver-runtime/values.yaml
@@ -58,6 +58,10 @@ affinity:
           operator: In
           values:
           - "true"
+        - key: harvesterhci.io/gpu-baremetal-workloads
+          operator: NotIn
+          values:
+          - "true"
 # http endpoint where nvidia kvm driver is hosted
 # this will be pulled and installed by the daemonset on runtime
 driverLocation: "HTTPENDPOINT/NVIDIA-Linux-x86_64-525.60.12-vgpu-kvm.run"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR adds an additional selector to ensure nvidia-driver-runtime can be skipped from certain nodes by applying the `harvesterhci.io/gpu-baremetal-workload=true` label to nodes.

This is needed for baremetal gpu container workload support

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5321

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
