### PR TITLE
feat: support harvester cloud provider to access config map

### DIFF
--- a/charts/harvester-cloud-provider/templates/rbac.yaml
+++ b/charts/harvester-cloud-provider/templates/rbac.yaml
@@ -20,6 +20,9 @@ rules:
   - apiGroups: [ "coordination.k8s.io" ]
     resources: [ "leases" ]
     verbs: [ "get", "update", "create" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "list", "watch", "create", "update" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
We use config map to store nad-interface information instead of node annotation right now. So, we need to access config map.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5486

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
