### PR TITLE
harvester-csi-driver: add configurable podSecurityContext for SELinux-enforcing clusters

### DIFF
--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
           volumeMounts:
             - mountPath: /csi/
               name: socket-dir
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "harvester-csi-driver.name" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/harvester-csi-driver/values.yaml
+++ b/charts/harvester-csi-driver/values.yaml
@@ -28,6 +28,11 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# Pod-level securityContext for the csi-controllers Deployment. On guest clusters
+# with SELinux enforcing, set seLinuxOptions.type: spc_t to match the DaemonSet
+# pods that create the CSI socket (see harvester/harvester#10786).
+podSecurityContext: {}
+
 # This field can be used to specify the corresponding StorageClass on the host cluster.
 hostStorageClass: ""
 kubeletRootDir: /var/lib/kubelet


### PR DESCRIPTION
## Summary
Adds an optional `podSecurityContext` values field to the harvester-csi-driver
chart's csi-controllers Deployment, mirroring the fix already merged for
harvester-cloud-provider in #511.

## Problem
On guest RKE2 clusters with SELinux enforcing, the csi-controllers Deployment's
sidecar containers (csi-attacher, csi-provisioner, csi-resizer, csi-snapshotter)
run under the `container_t` SELinux type, while the csi-driver DaemonSet pods
that create /csi/csi.sock run under `spc_t` (privileged/unconfined). SELinux
type enforcement blocks container_t processes from connecting to a
container_var_lib_t-labeled socket created by an spc_t process, so all four
sidecars CrashLoopBackOff with "permission denied" dialing /csi/csi.sock.

Full repro and diagnosis in harvester/harvester#10786, including confirmation
that this reproduces independent of sidecar image version (v3.2.1 through
v4.11.0 for csi-attacher, etc.) — it's the SELinux type mismatch, not the
sidecar image build, that's at fault.

## Fix
Add an optional `podSecurityContext` field (default `{}`, no behavior change)
rendered onto the csi-controllers Deployment's pod spec. Operators on
SELinux-enforcing clusters can then set:

    podSecurityContext:
      seLinuxOptions:
        type: spc_t

## Testing
Verified live on an SELinux-enforcing RKE2 guest cluster (3 control-plane
nodes): with this change plus the values override above, all 3 replicas of
harvester-csi-driver-controllers reach 4/4 Ready, where they previously
CrashLoopBackOff'd on every node without it.