### PR TITLE
chart: add image pull secret support to harvester-csi-driver

### DIFF
--- a/charts/harvester-csi-driver/templates/_helpers.tpl
+++ b/charts/harvester-csi-driver/templates/_helpers.tpl
@@ -60,3 +60,25 @@ Global system default registry
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render imagePullSecrets, accepting either strings or object references.
+*/}}
+{{- define "harvester-csi-driver.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.cattle.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- if .name -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- end -}}
+  {{- else if not (empty .) -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (empty $pullSecrets) -}}
+imagePullSecrets:
+  {{- range $pullSecrets | uniq }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/harvester-csi-driver/templates/daemonset.yaml
+++ b/charts/harvester-csi-driver/templates/daemonset.yaml
@@ -16,6 +16,7 @@ spec:
         component: csi-driver
         {{- include "harvester-csi-driver.selectorLabels" . | nindent 8 }}
     spec:
+      {{- include "harvester-csi-driver.imagePullSecrets" . | nindent 6 }}
       containers:
         - args:
             - --v=5

--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         component: csi-controllers
         {{- include "harvester-csi-driver.selectorLabels" . | nindent 8 }}
     spec:
+      {{- include "harvester-csi-driver.imagePullSecrets" . | nindent 6 }}
       containers:
         - args:
             - --v=5

--- a/charts/harvester-csi-driver/values.yaml
+++ b/charts/harvester-csi-driver/values.yaml
@@ -56,3 +56,6 @@ tolerations:
 global:
   cattle:
     systemDefaultRegistry: ""
+    # Optional pull secrets for private registries.
+    # Referenced secrets must exist in the chart release namespace (normally kube-system).
+    imagePullSecrets: []


### PR DESCRIPTION
## Summary

- expose `global.cattle.imagePullSecrets` in the Harvester CSI driver chart
- normalize string and `{name: ...}` secret references through a shared Helm helper
- apply configured pull secrets to both the controller Deployment and node DaemonSet

## Why

This adds private-registry authentication support requested by rancher/rancher#54979. The chart already supports `global.cattle.systemDefaultRegistry`, but its workloads did not expose the corresponding image pull secrets.

## Impact

The default value is an empty list, so existing installations render the same workload configuration. When configured, both workload PodSpecs receive `imagePullSecrets` entries.

## Validation

Lint the chart:

```bash
helm lint charts/harvester-csi-driver
```

Inspect the configured output:

```bash
helm template csi-test charts/harvester-csi-driver \
  --namespace kube-system \
  --set-string 'global.cattle.imagePullSecrets[0]=private-registry' \
  | grep -A2 imagePullSecrets
```

This should produce two occurrences—one for the Deployment and one for the DaemonSet:

```yaml
imagePullSecrets:
  - name: "private-registry"
```

Confirm the default remains unchanged:

```bash
helm template csi-test charts/harvester-csi-driver \
  --namespace kube-system \
  | grep imagePullSecrets
```

This should produce no output.

After installing or upgrading the chart, check the live workloads:

```bash
kubectl -n kube-system get deployment harvester-csi-driver-controllers \
  -o jsonpath='{.spec.template.spec.imagePullSecrets}{"\n"}'

kubectl -n kube-system get daemonset harvester-csi-driver \
  -o jsonpath='{.spec.template.spec.imagePullSecrets}{"\n"}'
```

Related to rancher/rancher#54979
