### PR TITLE
Release Harvester CSI Driver chart v0.1.31

### DIFF
--- a/charts/harvester-csi-driver/Chart.yaml
+++ b/charts/harvester-csi-driver/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.30
+version: 0.1.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/harvester-csi-driver/templates/_helpers.tpl
+++ b/charts/harvester-csi-driver/templates/_helpers.tpl
@@ -60,3 +60,25 @@ Global system default registry
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render imagePullSecrets, accepting either strings or object references.
+*/}}
+{{- define "harvester-csi-driver.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.cattle.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- if .name -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- end -}}
+  {{- else if not (empty .) -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (empty $pullSecrets) -}}
+imagePullSecrets:
+  {{- range $pullSecrets | uniq }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/harvester-csi-driver/templates/daemonset.yaml
+++ b/charts/harvester-csi-driver/templates/daemonset.yaml
@@ -16,6 +16,7 @@ spec:
         component: csi-driver
         {{- include "harvester-csi-driver.selectorLabels" . | nindent 8 }}
     spec:
+      {{- include "harvester-csi-driver.imagePullSecrets" . | nindent 6 }}
       containers:
         - args:
             - --v=5

--- a/charts/harvester-csi-driver/templates/deployment.yaml
+++ b/charts/harvester-csi-driver/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         component: csi-controllers
         {{- include "harvester-csi-driver.selectorLabels" . | nindent 8 }}
     spec:
+      {{- include "harvester-csi-driver.imagePullSecrets" . | nindent 6 }}
       containers:
         - args:
             - --v=5

--- a/charts/harvester-csi-driver/values.yaml
+++ b/charts/harvester-csi-driver/values.yaml
@@ -57,3 +57,6 @@ tolerations:
 global:
   cattle:
     systemDefaultRegistry: ""
+    # Optional pull secrets for private registries.
+    # Referenced secrets must exist in the chart release namespace (normally kube-system).
+    imagePullSecrets: []


### PR DESCRIPTION
#### Problem:

Harvester needs a new Harvester CSI Driver chart release for v0.1.31.

#### Solution:

Release Harvester CSI Driver chart v0.1.31. This release adds support for configuring image pull secrets for the controller Deployment and node DaemonSet, accepting both string and object-style secret references.

#### Related Issue(s):

https://github.com/harvester/harvester/issues/11383

#### Test plan:

- `helm lint charts/harvester-csi-driver`
- Render the chart with default values.
- Render the chart with `global.cattle.imagePullSecrets` using a string reference.
- Render the chart with `global.cattle.imagePullSecrets` using an object-style reference.

#### Additional documentation or context

The chart continues to use Harvester CSI Driver app version v0.2.9.
