### PR TITLE
Fix the ci target branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,10 +79,6 @@ jobs:
         run: ct install --config tests/ct-install.yaml
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Run chart-testing (install-lvm)
-        run: ct install --config tests/ct.yaml --charts charts/harvester-csi-driver-lvm
-        if: steps.list-changed.outputs.changed == 'true'
-
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/release')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,9 +77,11 @@ jobs:
 
       - name: Run chart-testing (install-generic)
         run: ct install --config tests/ct-install.yaml
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install-lvm)
         run: ct install --config tests/ct.yaml --charts charts/harvester-csi-driver-lvm
+        if: steps.list-changed.outputs.changed == 'true'
 
   release:
     runs-on: ubuntu-latest

--- a/tests/ct-install.yaml
+++ b/tests/ct-install.yaml
@@ -1,5 +1,5 @@
 remote: upstream
-target-branch: master
+target-branch: release
 chart-dirs:
   - charts
 excluded-charts:

--- a/tests/ct.yaml
+++ b/tests/ct.yaml
@@ -1,4 +1,4 @@
 remote: upstream
-target-branch: master
+target-branch: release
 chart-dirs:
   - charts


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

CI action upon PR https://github.com/harvester/charts/pull/593 failed, and the chart was not successfully released.

When update HCP chart, the CI flow on master and release are different

CI on master

<img width="2452" height="1762" alt="image" src="https://github.com/user-attachments/assets/9ee92cce-bbda-4c44-ad67-317dcb9efb95" />


CI on `release`:

note: CI seems to work on wrong charts...

<img width="2716" height="1730" alt="image" src="https://github.com/user-attachments/assets/8c19a29a-270b-46e4-9af4-ab2c212d536d" />


On release branch, the CI looks to have mixed master and release


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Update CI

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11400

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
